### PR TITLE
More core components, refactor component organization

### DIFF
--- a/data/components.js
+++ b/data/components.js
@@ -1,5 +1,44 @@
 export default [
 	{
+		'name': 'Alert',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/alert#d2l-alert',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-alert',
+		'type': 'Feedback'
+	}, {
+		'name': 'Alert - Toast',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/alert#d2l-alert-toast',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-alert-toast',
+		'type': 'Feedback'
+	}, {
+		'name': 'Backdrop',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/alert#d2l-alert-toast',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'alert',
+			'text': 'incomplete'
+		},
+		'tag': 'd2l-backdrop',
+		'type': 'Overlay'
+	}, {
 		'name': 'Button',
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/button#d2l-button',
 		'development': {
@@ -11,7 +50,7 @@ export default [
 			'text': 'complete'
 		},
 		'tag': 'd2l-button',
-		'type': 'action'
+		'type': 'Actions'
 	}, {
 		'name': 'Button - Icon',
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/button#d2l-button-icon',
@@ -24,9 +63,74 @@ export default [
 			'text': 'complete'
 		},
 		'tag': 'd2l-button-icon',
-		'type': 'action'
+		'type': 'Actions'
 	}, {
-		'name': 'Text Input',
+		'name': 'Button - Subtle',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/button#d2l-button-subtle',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-button-subtle',
+		'type': 'Actions'
+	}, {
+		'name': 'Floating Buttons',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/button#d2l-floating-buttons',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'alert',
+			'text': 'incomplete'
+		},
+		'tag': 'd2l-floating-buttons',
+		'type': 'grouping'
+	}, {
+		'name': 'Calendar',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/calendar#calendar',
+		'development': {
+			'state': 'default',
+			'text': 'in progress'
+		},
+		'design': {
+			'state': 'default',
+			'text': 'in progress'
+		},
+		'tag': 'd2l-calendar',
+		'type': 'Forms'
+	}, {
+		'name': 'Dialog',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dialog#d2l-dialog',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-dialog',
+		'type': 'Overlay'
+	}, {
+		'name': 'Dialog - Confirm',
+		'readme': 'hhttps://github.com/BrightspaceUI/core/tree/master/components/dialog#d2l-dialog-confirm',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-dialog-confirm',
+		'type': 'Overlay'
+	}, {
+		'name': 'Input - Text',
 		'readme': 'https://github.com/BrightspaceUI/core/blob/master/components/inputs/docs/input-text.md#text-inputs',
 		'development': {
 			'state': 'success',
@@ -37,6 +141,58 @@ export default [
 			'text': 'complete'
 		},
 		'tag': 'd2l-input-text',
-		'type': 'form'
+		'type': 'Forms'
+	}, {
+		'name': 'Input - Date',
+		'readme': 'https://github.com/BrightspaceUI/core/blob/master/components/inputs/docs/input-text.md#text-inputs',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-input-date',
+		'type': 'Forms'
+	}, {
+		'name': 'Input - Time',
+		'readme': 'https://github.com/BrightspaceUI/core/blob/master/components/inputs/docs/input-text.md#text-inputs',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-input-time',
+		'type': 'Forms'
+	}, {
+		'name': 'Input - Date & Time',
+		'readme': 'https://github.com/BrightspaceUI/core/blob/master/components/inputs/docs/input-text.md#text-inputs',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-input-date-time',
+		'type': 'Forms'
+	}, {
+		'name': 'Input - Search',
+		'readme': 'https://github.com/BrightspaceUI/core/blob/master/components/inputs/docs/input-text.md#text-inputs',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-input-search',
+		'type': 'Forms'
 	}
 ];

--- a/data/components.js
+++ b/data/components.js
@@ -102,7 +102,7 @@ export default [
 			'text': 'incomplete'
 		},
 		'tag': 'd2l-floating-buttons',
-		'type': 'grouping'
+		'type': 'Structure'
 	}, {
 		'name': 'Calendar',
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/calendar#calendar',

--- a/data/components.js
+++ b/data/components.js
@@ -3,8 +3,8 @@ export default [
 		'name': 'Inline Alert',
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/alert#d2l-alert',
 		'development': {
-			'state': 'success',
-			'text': 'complete'
+			'state': 'default',
+			'text': 'out of date'
 		},
 		'design': {
 			'state': 'success',
@@ -16,8 +16,8 @@ export default [
 		'name': 'Toast Alert',
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/alert#d2l-alert-toast',
 		'development': {
-			'state': 'success',
-			'text': 'complete'
+			'state': 'default',
+			'text': 'out of date'
 		},
 		'design': {
 			'state': 'success',
@@ -39,11 +39,24 @@ export default [
 		'tag': 'd2l-backdrop',
 		'type': 'Overlay'
 	}, {
-		'name': 'Button',
-		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/button#d2l-button',
+		'name': 'Breadcrumbs',
+		'readme': 'https://github.com/BrightspaceUI/breadcrumbs#d2l-breadcrumbs',
 		'development': {
 			'state': 'success',
 			'text': 'complete'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-breadcrumbs',
+		'type': 'Navigation'
+	}, {
+		'name': 'Button',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/button#d2l-button',
+		'development': {
+			'state': 'default',
+			'text': 'out of date'
 		},
 		'design': {
 			'state': 'success',
@@ -104,6 +117,19 @@ export default [
 		'tag': 'd2l-calendar',
 		'type': 'Forms'
 	}, {
+		'name': 'Card',
+		'readme': 'https://github.com/BrightspaceUI/card#d2l-card',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-card',
+		'type': 'Structure'
+	}, {
 		'name': 'Dialog',
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dialog#d2l-dialog',
 		'development': {
@@ -133,8 +159,8 @@ export default [
 		'name': 'Dropdown - Opener - Generic Wrapper',
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown',
 		'development': {
-			'state': 'success',
-			'text': 'complete'
+			'state': 'default',
+			'text': 'out of date'
 		},
 		'design': {
 			'state': 'success',
@@ -302,6 +328,19 @@ export default [
 		'name': 'Search Input',
 		'readme': 'https://github.com/BrightspaceUI/core/blob/master/components/inputs/docs/input-search.md#search-inputs',
 		'development': {
+			'state': 'default',
+			'text': 'out of date'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-input-search',
+		'type': 'Navigation'
+	}, {
+		'name': 'Select List Styles',
+		'readme': 'https://github.com/BrightspaceUI/core/blob/master/components/inputs/docs/input-select-styles.md#select-lists',
+		'development': {
 			'state': 'success',
 			'text': 'complete'
 		},
@@ -309,7 +348,7 @@ export default [
 			'state': 'success',
 			'text': 'complete'
 		},
-		'tag': 'd2l-input-search',
+		'tag': 'input-select-styles',
 		'type': 'Navigation'
 	}, {
 		'name': 'Link',
@@ -493,5 +532,174 @@ export default [
 		},
 		'tag': 'd2l-more-less',
 		'type': 'Structure'
+	}, {
+		'name': 'Navigation',
+		'readme': 'https://github.com/BrightspaceUI/navigation#d2l-navigation',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-navigation',
+		'type': 'Navigation'
+	}, {
+		'name': 'Immersive Navigation',
+		'readme': 'https://github.com/BrightspaceUI/navigation#d2l-navigation-immersive',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-navigation-immersive',
+		'type': 'Navigation'
+	}, {
+		'name': 'Offscreen',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/offscreen#off-screen-content',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'alert',
+			'text': 'incomplete'
+		},
+		'tag': 'd2l-offscreen',
+		'type': 'Structure'
+	}, {
+		'name': 'Profile Image',
+		'readme': 'https://github.com/BrightspaceHypermediaComponents/users',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-profile-image',
+		'type': 'Other'
+	}, {
+		'name': 'Filter Dropdown',
+		'readme': 'https://github.com/BrightspaceUI/facet-filter-sort#d2l-filter-dropdown',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'alert',
+			'text': 'incomplete'
+		},
+		'tag': 'd2l-filter-dropdown',
+		'type': 'Actions'
+	}, {
+		'name': 'Sort Dropdown',
+		'readme': 'https://github.com/BrightspaceUI/facet-filter-sort#d2l-sort-by-dropdown',
+		'development': {
+			'state': 'default',
+			'text': 'out of date'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-sort-by-dropdown',
+		'type': 'Actions'
+	}, {
+		'name': 'Search Facets',
+		'readme': 'https://github.com/BrightspaceUI/facet-filter-sort#d2l-search-facets',
+		'development': {
+			'state': 'default',
+			'text': 'out of date'
+		},
+		'design': {
+			'state': 'alert',
+			'text': 'incomplete'
+		},
+		'tag': 'd2l-search-facets',
+		'type': 'Actions'
+	}, {
+		'name': 'Search Results Count',
+		'readme': 'https://github.com/BrightspaceUI/facet-filter-sort#d2l-search-results-count',
+		'development': {
+			'state': 'default',
+			'text': 'out of date'
+		},
+		'design': {
+			'state': 'alert',
+			'text': 'incomplete'
+		},
+		'tag': 'd2l-search-results-count',
+		'type': 'Actions'
+	}, {
+		'name': 'Applied Filters',
+		'readme': 'https://github.com/BrightspaceUI/facet-filter-sort#d2l-applied-filters',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'alert',
+			'text': 'incomplete'
+		},
+		'tag': 'd2l-applied-filters',
+		'type': 'Actions'
+	}, {
+		'name': 'Status Indicator',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/status-indicator#d2l-status-indicator',
+		'development': {
+			'state': 'default',
+			'text': 'out of date'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-status-indicator',
+		'type': 'Feedback'
+	}, {
+		'name': 'Table',
+		'readme': 'https://github.com/BrightspaceUI/table#d2l-table',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-table',
+		'type': 'Structure'
+	}, {
+		'name': 'Tabs',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/tabs#d2l-tabs',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-tabs',
+		'type': 'Structure'
+	}, {
+		'name': 'Tooltip',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/tooltip#d2l-tooltip',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-tooltip',
+		'type': 'Feedback'
 	}
 ];

--- a/data/components.js
+++ b/data/components.js
@@ -1,6 +1,6 @@
 export default [
 	{
-		'name': 'Alert',
+		'name': 'Inline Alert',
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/alert#d2l-alert',
 		'development': {
 			'state': 'success',
@@ -13,7 +13,7 @@ export default [
 		'tag': 'd2l-alert',
 		'type': 'Feedback'
 	}, {
-		'name': 'Alert - Toast',
+		'name': 'Toast Alert',
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/alert#d2l-alert-toast',
 		'development': {
 			'state': 'success',
@@ -52,7 +52,7 @@ export default [
 		'tag': 'd2l-button',
 		'type': 'Actions'
 	}, {
-		'name': 'Button - Icon',
+		'name': 'Icon Button',
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/button#d2l-button-icon',
 		'development': {
 			'state': 'success',
@@ -65,7 +65,7 @@ export default [
 		'tag': 'd2l-button-icon',
 		'type': 'Actions'
 	}, {
-		'name': 'Button - Subtle',
+		'name': 'Subtle Button',
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/button#d2l-button-subtle',
 		'development': {
 			'state': 'success',
@@ -94,8 +94,8 @@ export default [
 		'name': 'Calendar',
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/calendar#calendar',
 		'development': {
-			'state': 'default',
-			'text': 'in progress'
+			'state': 'success',
+			'text': 'complete'
 		},
 		'design': {
 			'state': 'default',
@@ -117,8 +117,8 @@ export default [
 		'tag': 'd2l-dialog',
 		'type': 'Overlay'
 	}, {
-		'name': 'Dialog - Confirm',
-		'readme': 'hhttps://github.com/BrightspaceUI/core/tree/master/components/dialog#d2l-dialog-confirm',
+		'name': 'Confirmation Dialog',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dialog#d2l-dialog-confirm',
 		'development': {
 			'state': 'success',
 			'text': 'complete'
@@ -130,7 +130,124 @@ export default [
 		'tag': 'd2l-dialog-confirm',
 		'type': 'Overlay'
 	}, {
-		'name': 'Input - Text',
+		'name': 'Dropdown - Opener - Generic Wrapper',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-dropdown',
+		'type': 'Actions'
+	}, {
+		'name': 'Dropdown - Opener - Button',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown-button',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-dropdown-button',
+		'type': 'Actions'
+	}, {
+		'name': 'Dropdown - Opener - Subtle Button',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown-button-subtle',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-dropdown-button-subtle',
+		'type': 'Actions'
+	}, {
+		'name': 'Dropdown - Opener - Context Menu',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown-context-menu',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'alert',
+			'text': 'incomplete'
+		},
+		'tag': 'd2l-dropdown-context-menu',
+		'type': 'Actions'
+	}, {
+		'name': 'Dropdown - Opener - More',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown-more',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'alert',
+			'text': 'incomplete'
+		},
+		'tag': 'd2l-dropdown-more',
+		'type': 'Actions'
+	}, {
+		'name': 'Dropdown - Content - Generic',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown-content',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'alert',
+			'text': 'incomplete'
+		},
+		'tag': 'd2l-dropdown-content',
+		'type': 'Actions'
+	}, {
+		'name': 'Dropdown - Content - Menu',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown-menu',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-dropdown-menu',
+		'type': 'Actions'
+	}, {
+		'name': 'Dropdown - Content - Tabs',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown-tabs',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'alert',
+			'text': 'incomplete'
+		},
+		'tag': 'd2l-dropdown-tabs',
+		'type': 'Actions'
+	}, {
+		'name': 'Checkbox',
+		'readme': 'https://github.com/BrightspaceUI/core/blob/master/components/inputs/docs/input-checkbox.md#checkboxes',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-input-checkbox',
+		'type': 'Forms'
+	}, {
+		'name': 'Text Input',
 		'readme': 'https://github.com/BrightspaceUI/core/blob/master/components/inputs/docs/input-text.md#text-inputs',
 		'development': {
 			'state': 'success',
@@ -143,47 +260,47 @@ export default [
 		'tag': 'd2l-input-text',
 		'type': 'Forms'
 	}, {
-		'name': 'Input - Date',
-		'readme': 'https://github.com/BrightspaceUI/core/blob/master/components/inputs/docs/input-text.md#text-inputs',
+		'name': 'Date Picker',
+		'readme': 'https://github.com/BrightspaceUI/core/blob/master/components/inputs/docs/input-date-time.md#date-inputs',
 		'development': {
 			'state': 'success',
 			'text': 'complete'
 		},
 		'design': {
-			'state': 'success',
-			'text': 'complete'
+			'state': 'default',
+			'text': 'in progress'
 		},
 		'tag': 'd2l-input-date',
 		'type': 'Forms'
 	}, {
-		'name': 'Input - Time',
-		'readme': 'https://github.com/BrightspaceUI/core/blob/master/components/inputs/docs/input-text.md#text-inputs',
+		'name': 'Time Picker',
+		'readme': 'https://github.com/BrightspaceUI/core/blob/master/components/inputs/docs/input-date-time.md#time-inputs',
 		'development': {
 			'state': 'success',
 			'text': 'complete'
 		},
 		'design': {
-			'state': 'success',
-			'text': 'complete'
+			'state': 'default',
+			'text': 'in progress'
 		},
 		'tag': 'd2l-input-time',
 		'type': 'Forms'
 	}, {
-		'name': 'Input - Date & Time',
-		'readme': 'https://github.com/BrightspaceUI/core/blob/master/components/inputs/docs/input-text.md#text-inputs',
+		'name': 'Date & Time Picker',
+		'readme': 'https://github.com/BrightspaceUI/core/blob/master/components/inputs/docs/input-date-time.md#date-time-inputs',
 		'development': {
 			'state': 'success',
 			'text': 'complete'
 		},
 		'design': {
-			'state': 'success',
-			'text': 'complete'
+			'state': 'default',
+			'text': 'in progress'
 		},
 		'tag': 'd2l-input-date-time',
 		'type': 'Forms'
 	}, {
-		'name': 'Input - Search',
-		'readme': 'https://github.com/BrightspaceUI/core/blob/master/components/inputs/docs/input-text.md#text-inputs',
+		'name': 'Search Input',
+		'readme': 'https://github.com/BrightspaceUI/core/blob/master/components/inputs/docs/input-search.md#search-inputs',
 		'development': {
 			'state': 'success',
 			'text': 'complete'
@@ -193,6 +310,188 @@ export default [
 			'text': 'complete'
 		},
 		'tag': 'd2l-input-search',
-		'type': 'Forms'
+		'type': 'Navigation'
+	}, {
+		'name': 'Link',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/link#links',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'default',
+			'text': 'in progress'
+		},
+		'tag': 'd2l-link',
+		'type': 'Navigation'
+	}, {
+		'name': 'List',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/list#d2l-list',
+		'development': {
+			'state': 'default',
+			'text': 'in progress'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-list',
+		'type': 'Structure'
+	}, {
+		'name': 'List Item',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/list#d2l-list-item',
+		'development': {
+			'state': 'default',
+			'text': 'in progress'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-list-item',
+		'type': 'Structure'
+	}, {
+		'name': 'List Content',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/list#d2l-list-content',
+		'development': {
+			'state': 'default',
+			'text': 'in progress'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-list-content',
+		'type': 'Structure'
+	}, {
+		'name': 'Loading Spinner',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/loading-spinner',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'alert',
+			'text': 'incomplete'
+		},
+		'tag': 'd2l-loading-spinner',
+		'type': 'Feedback'
+	}, {
+		'name': 'Menu',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/menu#d2l-menu',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-menu',
+		'type': 'Actions'
+	}, {
+		'name': 'Menu Item',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/menu#d2l-menu-item',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-menu-item',
+		'type': 'Actions'
+	}, {
+		'name': 'Menu Item - Link',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/menu#d2l-menu-item-link',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'alert',
+			'text': 'incomplete'
+		},
+		'tag': 'd2l-menu-item-link',
+		'type': 'Actions'
+	}, {
+		'name': 'Menu Item - Checkbox',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/menu#d2l-menu-item-checkbox',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'alert',
+			'text': 'incomplete'
+		},
+		'tag': 'd2l-menu-item-checkbox',
+		'type': 'Actions'
+	}, {
+		'name': 'Menu Item - Radio',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/menu#d2l-menu-item-radio',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'alert',
+			'text': 'incomplete'
+		},
+		'tag': 'd2l-menu-item-radio',
+		'type': 'Actions'
+	}, {
+		'name': 'Meter - Linear',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/meter#d2l-meter-linear',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-meter-linear',
+		'type': 'Other'
+	}, {
+		'name': 'Meter - Radial',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/meter#d2l-meter-radial',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-meter-radial',
+		'type': 'Other'
+	}, {
+		'name': 'Meter - Circle',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/meter#d2l-meter-circle',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'tag': 'd2l-meter-circle',
+		'type': 'Other'
+	}, {
+		'name': 'More/Less',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/more-less#more-less',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'alert',
+			'text': 'incomplete'
+		},
+		'tag': 'd2l-more-less',
+		'type': 'Structure'
 	}
 ];

--- a/data/components.js
+++ b/data/components.js
@@ -156,109 +156,112 @@ export default [
 		'tag': 'd2l-dialog-confirm',
 		'type': 'Overlay'
 	}, {
-		'name': 'Dropdown - Opener - Generic Wrapper',
-		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown',
-		'development': {
-			'state': 'default',
-			'text': 'out of date'
-		},
-		'design': {
-			'state': 'success',
-			'text': 'complete'
-		},
-		'tag': 'd2l-dropdown',
-		'type': 'Actions'
-	}, {
-		'name': 'Dropdown - Opener - Button',
-		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown-button',
-		'development': {
-			'state': 'success',
-			'text': 'complete'
-		},
-		'design': {
-			'state': 'success',
-			'text': 'complete'
-		},
-		'tag': 'd2l-dropdown-button',
-		'type': 'Actions'
-	}, {
-		'name': 'Dropdown - Opener - Subtle Button',
-		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown-button-subtle',
-		'development': {
-			'state': 'success',
-			'text': 'complete'
-		},
-		'design': {
-			'state': 'success',
-			'text': 'complete'
-		},
-		'tag': 'd2l-dropdown-button-subtle',
-		'type': 'Actions'
-	}, {
-		'name': 'Dropdown - Opener - Context Menu',
-		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown-context-menu',
-		'development': {
-			'state': 'success',
-			'text': 'complete'
-		},
-		'design': {
-			'state': 'alert',
-			'text': 'incomplete'
-		},
-		'tag': 'd2l-dropdown-context-menu',
-		'type': 'Actions'
-	}, {
-		'name': 'Dropdown - Opener - More',
-		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown-more',
-		'development': {
-			'state': 'success',
-			'text': 'complete'
-		},
-		'design': {
-			'state': 'alert',
-			'text': 'incomplete'
-		},
-		'tag': 'd2l-dropdown-more',
-		'type': 'Actions'
-	}, {
-		'name': 'Dropdown - Content - Generic',
-		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown-content',
-		'development': {
-			'state': 'success',
-			'text': 'complete'
-		},
-		'design': {
-			'state': 'alert',
-			'text': 'incomplete'
-		},
-		'tag': 'd2l-dropdown-content',
-		'type': 'Actions'
-	}, {
-		'name': 'Dropdown - Content - Menu',
-		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown-menu',
-		'development': {
-			'state': 'success',
-			'text': 'complete'
-		},
-		'design': {
-			'state': 'success',
-			'text': 'complete'
-		},
-		'tag': 'd2l-dropdown-menu',
-		'type': 'Actions'
-	}, {
-		'name': 'Dropdown - Content - Tabs',
-		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown-tabs',
-		'development': {
-			'state': 'success',
-			'text': 'complete'
-		},
-		'design': {
-			'state': 'alert',
-			'text': 'incomplete'
-		},
-		'tag': 'd2l-dropdown-tabs',
-		'type': 'Actions'
+		'name': 'Dropdown',
+		'type': 'Actions',
+		'childComponents': [{
+			'name': 'Dropdown - Opener - Generic Wrapper',
+			'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown',
+			'development': {
+				'state': 'default',
+				'text': 'out of date'
+			},
+			'design': {
+				'state': 'success',
+				'text': 'complete'
+			},
+			'tag': 'd2l-dropdown'
+		}, {
+			'name': 'Dropdown - Opener - Button',
+			'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown-button',
+			'development': {
+				'state': 'success',
+				'text': 'complete'
+			},
+			'design': {
+				'state': 'success',
+				'text': 'complete'
+			},
+			'tag': 'd2l-dropdown-button',
+			'type': 'Actions'
+		}, {
+			'name': 'Dropdown - Opener - Subtle Button',
+			'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown-button-subtle',
+			'development': {
+				'state': 'success',
+				'text': 'complete'
+			},
+			'design': {
+				'state': 'success',
+				'text': 'complete'
+			},
+			'tag': 'd2l-dropdown-button-subtle',
+			'type': 'Actions'
+		}, {
+			'name': 'Dropdown - Opener - Context Menu',
+			'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown-context-menu',
+			'development': {
+				'state': 'success',
+				'text': 'complete'
+			},
+			'design': {
+				'state': 'alert',
+				'text': 'incomplete'
+			},
+			'tag': 'd2l-dropdown-context-menu',
+			'type': 'Actions'
+		}, {
+			'name': 'Dropdown - Opener - More',
+			'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown-more',
+			'development': {
+				'state': 'success',
+				'text': 'complete'
+			},
+			'design': {
+				'state': 'alert',
+				'text': 'incomplete'
+			},
+			'tag': 'd2l-dropdown-more',
+			'type': 'Actions'
+		}, {
+			'name': 'Dropdown - Content - Generic',
+			'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown-content',
+			'development': {
+				'state': 'success',
+				'text': 'complete'
+			},
+			'design': {
+				'state': 'alert',
+				'text': 'incomplete'
+			},
+			'tag': 'd2l-dropdown-content',
+			'type': 'Actions'
+		}, {
+			'name': 'Dropdown - Content - Menu',
+			'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown-menu',
+			'development': {
+				'state': 'success',
+				'text': 'complete'
+			},
+			'design': {
+				'state': 'success',
+				'text': 'complete'
+			},
+			'tag': 'd2l-dropdown-menu',
+			'type': 'Actions'
+		}, {
+			'name': 'Dropdown - Content - Tabs',
+			'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown-tabs',
+			'development': {
+				'state': 'success',
+				'text': 'complete'
+			},
+			'design': {
+				'state': 'alert',
+				'text': 'incomplete'
+			},
+			'tag': 'd2l-dropdown-tabs',
+			'type': 'Actions'
+		}]
 	}, {
 		'name': 'Checkbox',
 		'readme': 'https://github.com/BrightspaceUI/core/blob/master/components/inputs/docs/input-checkbox.md#checkboxes',
@@ -349,7 +352,7 @@ export default [
 			'text': 'complete'
 		},
 		'tag': 'input-select-styles',
-		'type': 'Navigation'
+		'type': 'Forms'
 	}, {
 		'name': 'Link',
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/link#links',
@@ -417,69 +420,73 @@ export default [
 		'type': 'Feedback'
 	}, {
 		'name': 'Menu',
-		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/menu#d2l-menu',
-		'development': {
-			'state': 'success',
-			'text': 'complete'
-		},
-		'design': {
-			'state': 'success',
-			'text': 'complete'
-		},
-		'tag': 'd2l-menu',
-		'type': 'Actions'
-	}, {
-		'name': 'Menu Item',
-		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/menu#d2l-menu-item',
-		'development': {
-			'state': 'success',
-			'text': 'complete'
-		},
-		'design': {
-			'state': 'success',
-			'text': 'complete'
-		},
-		'tag': 'd2l-menu-item',
-		'type': 'Actions'
-	}, {
-		'name': 'Menu Item - Link',
-		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/menu#d2l-menu-item-link',
-		'development': {
-			'state': 'success',
-			'text': 'complete'
-		},
-		'design': {
-			'state': 'alert',
-			'text': 'incomplete'
-		},
-		'tag': 'd2l-menu-item-link',
-		'type': 'Actions'
-	}, {
-		'name': 'Menu Item - Checkbox',
-		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/menu#d2l-menu-item-checkbox',
-		'development': {
-			'state': 'success',
-			'text': 'complete'
-		},
-		'design': {
-			'state': 'alert',
-			'text': 'incomplete'
-		},
-		'tag': 'd2l-menu-item-checkbox',
-		'type': 'Actions'
-	}, {
-		'name': 'Menu Item - Radio',
-		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/menu#d2l-menu-item-radio',
-		'development': {
-			'state': 'success',
-			'text': 'complete'
-		},
-		'design': {
-			'state': 'alert',
-			'text': 'incomplete'
-		},
-		'tag': 'd2l-menu-item-radio',
-		'type': 'Actions'
+		'type': 'Actions',
+		'childComponents': [{
+			'name': 'Menu',
+			'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/menu#d2l-menu',
+			'development': {
+				'state': 'success',
+				'text': 'complete'
+			},
+			'design': {
+				'state': 'success',
+				'text': 'complete'
+			},
+			'tag': 'd2l-menu',
+			'type': 'Actions'
+		}, {
+			'name': 'Menu Item',
+			'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/menu#d2l-menu-item',
+			'development': {
+				'state': 'success',
+				'text': 'complete'
+			},
+			'design': {
+				'state': 'success',
+				'text': 'complete'
+			},
+			'tag': 'd2l-menu-item',
+			'type': 'Actions'
+		}, {
+			'name': 'Menu Item - Link',
+			'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/menu#d2l-menu-item-link',
+			'development': {
+				'state': 'success',
+				'text': 'complete'
+			},
+			'design': {
+				'state': 'alert',
+				'text': 'incomplete'
+			},
+			'tag': 'd2l-menu-item-link',
+			'type': 'Actions'
+		}, {
+			'name': 'Menu Item - Checkbox',
+			'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/menu#d2l-menu-item-checkbox',
+			'development': {
+				'state': 'success',
+				'text': 'complete'
+			},
+			'design': {
+				'state': 'alert',
+				'text': 'incomplete'
+			},
+			'tag': 'd2l-menu-item-checkbox',
+			'type': 'Actions'
+		}, {
+			'name': 'Menu Item - Radio',
+			'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/menu#d2l-menu-item-radio',
+			'development': {
+				'state': 'success',
+				'text': 'complete'
+			},
+			'design': {
+				'state': 'alert',
+				'text': 'incomplete'
+			},
+			'tag': 'd2l-menu-item-radio',
+			'type': 'Actions'
+		}]
 	}, {
 		'name': 'Meter - Linear',
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/meter#d2l-meter-linear',
@@ -598,6 +605,19 @@ export default [
 		'tag': 'd2l-filter-dropdown',
 		'type': 'Actions'
 	}, {
+		'name': 'Applied Filters',
+		'readme': 'https://github.com/BrightspaceUI/facet-filter-sort#d2l-applied-filters',
+		'development': {
+			'state': 'success',
+			'text': 'complete'
+		},
+		'design': {
+			'state': 'alert',
+			'text': 'incomplete'
+		},
+		'tag': 'd2l-applied-filters',
+		'type': 'Actions'
+	}, {
 		'name': 'Sort Dropdown',
 		'readme': 'https://github.com/BrightspaceUI/facet-filter-sort#d2l-sort-by-dropdown',
 		'development': {
@@ -635,19 +655,6 @@ export default [
 			'text': 'incomplete'
 		},
 		'tag': 'd2l-search-results-count',
-		'type': 'Actions'
-	}, {
-		'name': 'Applied Filters',
-		'readme': 'https://github.com/BrightspaceUI/facet-filter-sort#d2l-applied-filters',
-		'development': {
-			'state': 'success',
-			'text': 'complete'
-		},
-		'design': {
-			'state': 'alert',
-			'text': 'incomplete'
-		},
-		'tag': 'd2l-applied-filters',
 		'type': 'Actions'
 	}, {
 		'name': 'Status Indicator',

--- a/data/components.js
+++ b/data/components.js
@@ -27,7 +27,7 @@ export default [
 		'type': 'Feedback'
 	}, {
 		'name': 'Backdrop',
-		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/alert#d2l-alert-toast',
+		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/backdrop#d2l-backdrop',
 		'development': {
 			'state': 'success',
 			'text': 'complete'

--- a/src/app.js
+++ b/src/app.js
@@ -108,19 +108,10 @@ export class DesignSystem extends LitElement {
 		this._shownNested = '';
 		this._installRoutes();
 
-		this._categories = {
-			'Actions': [],
-			'Feedback': [],
-			'Forms': [],
-			'Navigation': [],
-			'Overlay': [],
-			'Structure': [],
-			'Other': []
-		};
+		this._categories = {};
 		components.forEach((component) => {
-			Object.keys(this._categories).forEach((category) => {
-				if (component.type === category) this._categories[category].push(component);
-			});
+			if (!this._categories[component.type]) this._categories[component.type] = [];
+			this._categories[component.type].push(component);
 		});
 	}
 

--- a/src/app.js
+++ b/src/app.js
@@ -32,7 +32,6 @@ export class DesignSystem extends LitElement {
 				display: flex;
 				height: 4.5rem;
 				padding-left: 4.5rem;
-				// position: sticky;
 				top: 0;
 			}
 
@@ -52,7 +51,7 @@ export class DesignSystem extends LitElement {
 				background: linear-gradient(to right, #FFFFFF, #F9FAFB);
 				border-right: 1px solid #e6eaf0;
 				box-sizing: border-box;
-				flex: 0 1 30%;
+				flex: 0 1 24%;
 				padding-top: 1.5rem;
 				position: sticky;
 				top: 3rem;

--- a/src/app.js
+++ b/src/app.js
@@ -52,10 +52,11 @@ export class DesignSystem extends LitElement {
 				background: linear-gradient(to right, #FFFFFF, #F9FAFB);
 				border-right: 1px solid #e6eaf0;
 				box-sizing: border-box;
-				flex: 0 1 24%;
+				flex: 0 1 30%;
 				padding-top: 1.5rem;
-				// position: sticky;
+				position: sticky;
 				top: 3rem;
+				overflow-y: scroll;
 			}
 
 			.d2l-design-system-main {
@@ -66,7 +67,6 @@ export class DesignSystem extends LitElement {
 				padding-left: 1.5rem;
 				padding-right: 1.5rem;
 				padding-top: 2rem;
-				overflow-y: auto;
 			}
 
 			ul {
@@ -95,7 +95,15 @@ export class DesignSystem extends LitElement {
 		this._shownCategory = '';
 		this._installRoutes();
 
-		this._categories = {'Actions': [], 'Forms': [], 'Feedback': [], 'Overlay': []};
+		this._categories = {
+			'Actions': [],
+			'Feedback': [],
+			'Forms': [],
+			'Navigation': [],
+			'Overlay': [],
+			'Structure': [],
+			'Other': []
+		};
 		components.forEach((component) => {
 			Object.keys(this._categories).forEach((category) => {
 				if (component.type === category) this._categories[category].push(component);

--- a/src/app.js
+++ b/src/app.js
@@ -65,18 +65,20 @@ export class DesignSystem extends LitElement {
 				background-color: white;
 				flex: 1 1 auto;
 				overflow: scroll;
-				padding-bottom: 2rem;
-				padding-left: 1.5rem;
-				padding-right: 1.5rem;
-				padding-top: 2rem;
+				padding: 2rem 1.5rem;
 			}
 
 			ul {
 				padding-left: 4.5rem;
 			}
 
+			li {
+				list-style-type: none;
+				padding-bottom: 1rem;
+			}
+
 			ul ul {
-				padding-left: 1rem;
+				padding-left: 0.8rem;
 			}
 
 			ul ul li {
@@ -91,12 +93,7 @@ export class DesignSystem extends LitElement {
 				padding-left: 1.6rem;
 			}
 
-			li {
-				list-style-type: none;
-				padding-bottom: 1rem;
-			}
-
-			d2l-icon {
+			d2l-link d2l-icon {
 				color: var(--d2l-color-celestine);
 				margin-bottom: 0.25rem;
 			}

--- a/src/app.js
+++ b/src/app.js
@@ -215,7 +215,6 @@ export class DesignSystem extends LitElement {
 		const filtered1 = components.filter((component) => component.name === parentName);
 		const filtered2 = filtered1[0].childComponents.filter((component) =>  component.tag === componentName);
 		this._shownCategory = filtered1[0].type;
-		this._shownNested = filtered1[0].name;
 		this._component = JSON.stringify(filtered2[0]);
 	}
 

--- a/src/component-list.js
+++ b/src/component-list.js
@@ -34,6 +34,9 @@ export class DesignSystemComponentList extends LitElement {
 			d2l-table {
 				padding-top: 1rem;
 			}
+			d2l-link d2l-status-indicator {
+				cursor: pointer;
+			}
 		`];
 	}
 
@@ -48,11 +51,12 @@ export class DesignSystemComponentList extends LitElement {
 	render() {
 		const rows = components.map(component => {
 			if (this._filter && !component.name.toLowerCase().includes(this._filter.toLowerCase())) return null;
-			const name = component.readme ? html`<d2l-link href="${component.readme}">${component.name}</d2l-link>` : html`<div>${component.name}</div>`;
+			const baseState = html`<d2l-status-indicator state="${component.development.state}" text="${component.development.text}"></d2l-status-indicator>`;
+			const state = component.readme ? html`<d2l-link href="${component.readme}">${baseState}</d2l-link>` : baseState;
 			return html`
 				<d2l-tr>
-					<d2l-td>${name}</d2l-td>
-					<d2l-td><d2l-status-indicator state="${component.development.state}" text="${component.development.text}"></d2l-status-indicator></d2l-td>
+					<d2l-td><d2l-link href="/components/${component.tag}">${component.name}</d2l-link></d2l-td>
+					<d2l-td>${state}</d2l-td>
 					<d2l-td><d2l-status-indicator state="${component.design.state}" text="${component.design.text}"></d2l-status-indicator></d2l-td>
 				</d2l-tr>
 			`;

--- a/src/component-list.js
+++ b/src/component-list.js
@@ -31,9 +31,11 @@ export class DesignSystemComponentList extends LitElement {
 			d2l-input-search {
 				max-width: 50%;
 			}
+
 			d2l-table {
 				padding-top: 1rem;
 			}
+
 			d2l-link d2l-status-indicator {
 				cursor: pointer;
 			}

--- a/src/component-list.js
+++ b/src/component-list.js
@@ -51,15 +51,29 @@ export class DesignSystemComponentList extends LitElement {
 	render() {
 		const rows = components.map(component => {
 			if (this._filter && !component.name.toLowerCase().includes(this._filter.toLowerCase())) return null;
-			const baseState = html`<d2l-status-indicator state="${component.development.state}" text="${component.development.text}"></d2l-status-indicator>`;
-			const state = component.readme ? html`<d2l-link href="${component.readme}">${baseState}</d2l-link>` : baseState;
-			return html`
-				<d2l-tr>
-					<d2l-td><d2l-link href="/components/${component.tag}">${component.name}</d2l-link></d2l-td>
-					<d2l-td>${state}</d2l-td>
-					<d2l-td><d2l-status-indicator state="${component.design.state}" text="${component.design.text}"></d2l-status-indicator></d2l-td>
-				</d2l-tr>
-			`;
+			if (component.childComponents) {
+				return component.childComponents.map((childComponent) => {
+					const baseState = html`<d2l-status-indicator state="${childComponent.development.state}" text="${childComponent.development.text}"></d2l-status-indicator>`;
+					const state = childComponent.readme ? html`<d2l-link href="${childComponent.readme}">${baseState}</d2l-link>` : baseState;
+					return html`
+						<d2l-tr>
+							<d2l-td><d2l-link href="/components/${component.name}/${childComponent.tag}">${childComponent.name}</d2l-link></d2l-td>
+							<d2l-td>${state}</d2l-td>
+							<d2l-td><d2l-status-indicator state="${childComponent.design.state}" text="${childComponent.design.text}"></d2l-status-indicator></d2l-td>
+						</d2l-tr>
+					`;
+				});
+			} else {
+				const baseState = html`<d2l-status-indicator state="${component.development.state}" text="${component.development.text}"></d2l-status-indicator>`;
+				const state = component.readme ? html`<d2l-link href="${component.readme}">${baseState}</d2l-link>` : baseState;
+				return html`
+					<d2l-tr>
+						<d2l-td><d2l-link href="/components/${component.tag}">${component.name}</d2l-link></d2l-td>
+						<d2l-td>${state}</d2l-td>
+						<d2l-td><d2l-status-indicator state="${component.design.state}" text="${component.design.text}"></d2l-status-indicator></d2l-td>
+					</d2l-tr>
+				`;
+			}
 		});
 		return html`
 			<h1 class="d2l-heading-2">Component Status</h1>

--- a/src/component-list.js
+++ b/src/component-list.js
@@ -1,3 +1,4 @@
+import '@brightspace-ui/core/components/inputs/input-search.js';
 import '@brightspace-ui/core/components/link/link.js';
 import '@brightspace-ui/core/components/status-indicator/status-indicator.js';
 import 'd2l-table/d2l-table.js';
@@ -7,6 +8,12 @@ import { heading2Styles } from '@brightspace-ui/core/components/typography/style
 import { tableStyles } from './table-styles.js';
 
 export class DesignSystemComponentList extends LitElement {
+	static get properties() {
+		return {
+			_filter: { type: String }
+		};
+	}
+
 	static get styles() {
 		return [heading2Styles, tableStyles, css`
 			:host {
@@ -20,11 +27,27 @@ export class DesignSystemComponentList extends LitElement {
 			h1.d2l-heading-2 {
 				margin-top: 0;
 			}
+
+			d2l-input-search {
+				max-width: 50%;
+			}
+			d2l-table {
+				padding-top: 1rem;
+			}
 		`];
+	}
+
+	firstUpdated(changedProperties) {
+		super.firstUpdated(changedProperties);
+
+		this.shadowRoot.querySelector('d2l-input-search').addEventListener('d2l-input-search-searched', (e) => {
+			this._filter = e.detail.value;
+		});
 	}
 
 	render() {
 		const rows = components.map(component => {
+			if (this._filter && !component.name.toLowerCase().includes(this._filter.toLowerCase())) return null;
 			const name = component.readme ? html`<d2l-link href="${component.readme}">${component.name}</d2l-link>` : html`<div>${component.name}</div>`;
 			return html`
 				<d2l-tr>
@@ -36,6 +59,7 @@ export class DesignSystemComponentList extends LitElement {
 		});
 		return html`
 			<h1 class="d2l-heading-2">Component Status</h1>
+			<d2l-input-search label="Search individuals" placeholder="Filter results"></d2l-input-search>
 			<d2l-table class="d2l-table">
 				<d2l-thead>
 					<d2l-tr>

--- a/src/component.js
+++ b/src/component.js
@@ -4,6 +4,7 @@ export class DesignSystemComponent extends LitElement {
 	static get properties() {
 		return {
 			component: { type: String },
+			_componentInfo: { type: Object }
 		};
 	}
 
@@ -23,12 +24,21 @@ export class DesignSystemComponent extends LitElement {
 		super();
 
 		this.component = '';
+		this._componentInfo = {};
 	}
 
 	render() {
 		return html`
-			<div>${this.component}</div>
+			<h1>${this._componentInfo.name}</h1>
 		`;
+	}
+
+	updated(changedProperties) {
+		super.updated(changedProperties);
+
+		changedProperties.forEach((_, prop) => {
+			if (prop === 'component') this._componentInfo = JSON.parse(this.component);
+		});
 	}
 }
 customElements.define('d2l-design-system-component', DesignSystemComponent);


### PR DESCRIPTION
This adds all the core components and design specified components that have been implemented. Components are organized in the sidebar according to their `type` and nesting of components (e.g., the dropdown and menu components) in the sidebar is supported.

Current "out of date" status on components is mostly based on design site status.