### PR TITLE
Component status table: tweak style & messages

### DIFF
--- a/data/components.js
+++ b/data/components.js
@@ -3,12 +3,12 @@ export default [
 		'name': 'Inline Alert',
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/alert#d2l-alert',
 		'development': {
-			'state': 'default',
-			'text': 'out of date'
+			'state': 'action',
+			'text': 'Out of date'
 		},
 		'design': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'tag': 'd2l-alert',
 		'type': 'Feedback'
@@ -16,12 +16,12 @@ export default [
 		'name': 'Toast Alert',
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/alert#d2l-alert-toast',
 		'development': {
-			'state': 'default',
-			'text': 'out of date'
+			'state': 'action',
+			'text': 'Out of date'
 		},
 		'design': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'tag': 'd2l-alert-toast',
 		'type': 'Feedback'
@@ -30,11 +30,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/backdrop#d2l-backdrop',
 		'development': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'design': {
 			'state': 'alert',
-			'text': 'incomplete'
+			'text': 'No design'
 		},
 		'tag': 'd2l-backdrop',
 		'type': 'Overlay'
@@ -43,11 +43,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/breadcrumbs#d2l-breadcrumbs',
 		'development': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'design': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'tag': 'd2l-breadcrumbs',
 		'type': 'Navigation'
@@ -55,12 +55,12 @@ export default [
 		'name': 'Button',
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/button#d2l-button',
 		'development': {
-			'state': 'default',
-			'text': 'out of date'
+			'state': 'action',
+			'text': 'Out of date'
 		},
 		'design': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'tag': 'd2l-button',
 		'type': 'Actions'
@@ -69,11 +69,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/button#d2l-button-icon',
 		'development': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'design': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'tag': 'd2l-button-icon',
 		'type': 'Actions'
@@ -82,11 +82,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/button#d2l-button-subtle',
 		'development': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'design': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'tag': 'd2l-button-subtle',
 		'type': 'Actions'
@@ -95,11 +95,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/button#d2l-floating-buttons',
 		'development': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'design': {
 			'state': 'alert',
-			'text': 'incomplete'
+			'text': 'No design'
 		},
 		'tag': 'd2l-floating-buttons',
 		'type': 'Structure'
@@ -108,11 +108,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/calendar#calendar',
 		'development': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'design': {
 			'state': 'default',
-			'text': 'in progress'
+			'text': 'In progress'
 		},
 		'tag': 'd2l-calendar',
 		'type': 'Forms'
@@ -121,11 +121,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/card#d2l-card',
 		'development': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'design': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'tag': 'd2l-card',
 		'type': 'Structure'
@@ -134,11 +134,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dialog#d2l-dialog',
 		'development': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'design': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'tag': 'd2l-dialog',
 		'type': 'Overlay'
@@ -147,11 +147,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dialog#d2l-dialog-confirm',
 		'development': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'design': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'tag': 'd2l-dialog-confirm',
 		'type': 'Overlay'
@@ -162,12 +162,12 @@ export default [
 			'name': 'Dropdown - Opener - Generic Wrapper',
 			'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown',
 			'development': {
-				'state': 'default',
-				'text': 'out of date'
+				'state': 'action',
+				'text': 'Out of date'
 			},
 			'design': {
 				'state': 'success',
-				'text': 'complete'
+				'text': 'Complete'
 			},
 			'tag': 'd2l-dropdown'
 		}, {
@@ -175,11 +175,11 @@ export default [
 			'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown-button',
 			'development': {
 				'state': 'success',
-				'text': 'complete'
+				'text': 'Complete'
 			},
 			'design': {
 				'state': 'success',
-				'text': 'complete'
+				'text': 'Complete'
 			},
 			'tag': 'd2l-dropdown-button',
 			'type': 'Actions'
@@ -188,11 +188,11 @@ export default [
 			'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown-button-subtle',
 			'development': {
 				'state': 'success',
-				'text': 'complete'
+				'text': 'Complete'
 			},
 			'design': {
 				'state': 'success',
-				'text': 'complete'
+				'text': 'Complete'
 			},
 			'tag': 'd2l-dropdown-button-subtle',
 			'type': 'Actions'
@@ -201,11 +201,11 @@ export default [
 			'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown-context-menu',
 			'development': {
 				'state': 'success',
-				'text': 'complete'
+				'text': 'Complete'
 			},
 			'design': {
 				'state': 'alert',
-				'text': 'incomplete'
+				'text': 'No design'
 			},
 			'tag': 'd2l-dropdown-context-menu',
 			'type': 'Actions'
@@ -214,11 +214,11 @@ export default [
 			'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown-more',
 			'development': {
 				'state': 'success',
-				'text': 'complete'
+				'text': 'Complete'
 			},
 			'design': {
 				'state': 'alert',
-				'text': 'incomplete'
+				'text': 'No design'
 			},
 			'tag': 'd2l-dropdown-more',
 			'type': 'Actions'
@@ -227,11 +227,11 @@ export default [
 			'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown-content',
 			'development': {
 				'state': 'success',
-				'text': 'complete'
+				'text': 'Complete'
 			},
 			'design': {
 				'state': 'alert',
-				'text': 'incomplete'
+				'text': 'No design'
 			},
 			'tag': 'd2l-dropdown-content',
 			'type': 'Actions'
@@ -240,11 +240,11 @@ export default [
 			'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown-menu',
 			'development': {
 				'state': 'success',
-				'text': 'complete'
+				'text': 'Complete'
 			},
 			'design': {
 				'state': 'success',
-				'text': 'complete'
+				'text': 'Complete'
 			},
 			'tag': 'd2l-dropdown-menu',
 			'type': 'Actions'
@@ -253,11 +253,11 @@ export default [
 			'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/dropdown#d2l-dropdown-tabs',
 			'development': {
 				'state': 'success',
-				'text': 'complete'
+				'text': 'Complete'
 			},
 			'design': {
 				'state': 'alert',
-				'text': 'incomplete'
+				'text': 'No design'
 			},
 			'tag': 'd2l-dropdown-tabs',
 			'type': 'Actions'
@@ -267,11 +267,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/core/blob/master/components/inputs/docs/input-checkbox.md#checkboxes',
 		'development': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'design': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'tag': 'd2l-input-checkbox',
 		'type': 'Forms'
@@ -280,11 +280,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/core/blob/master/components/inputs/docs/input-text.md#text-inputs',
 		'development': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'design': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'tag': 'd2l-input-text',
 		'type': 'Forms'
@@ -293,11 +293,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/core/blob/master/components/inputs/docs/input-date-time.md#date-inputs',
 		'development': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'design': {
 			'state': 'default',
-			'text': 'in progress'
+			'text': 'In progress'
 		},
 		'tag': 'd2l-input-date',
 		'type': 'Forms'
@@ -306,11 +306,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/core/blob/master/components/inputs/docs/input-date-time.md#time-inputs',
 		'development': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'design': {
 			'state': 'default',
-			'text': 'in progress'
+			'text': 'In progress'
 		},
 		'tag': 'd2l-input-time',
 		'type': 'Forms'
@@ -319,11 +319,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/core/blob/master/components/inputs/docs/input-date-time.md#date-time-inputs',
 		'development': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'design': {
 			'state': 'default',
-			'text': 'in progress'
+			'text': 'In progress'
 		},
 		'tag': 'd2l-input-date-time',
 		'type': 'Forms'
@@ -331,12 +331,12 @@ export default [
 		'name': 'Search Input',
 		'readme': 'https://github.com/BrightspaceUI/core/blob/master/components/inputs/docs/input-search.md#search-inputs',
 		'development': {
-			'state': 'default',
-			'text': 'out of date'
+			'state': 'action',
+			'text': 'Out of date'
 		},
 		'design': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'tag': 'd2l-input-search',
 		'type': 'Navigation'
@@ -345,11 +345,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/core/blob/master/components/inputs/docs/input-select-styles.md#select-lists',
 		'development': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'design': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'tag': 'input-select-styles',
 		'type': 'Forms'
@@ -358,11 +358,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/link#links',
 		'development': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'design': {
 			'state': 'default',
-			'text': 'in progress'
+			'text': 'In progress'
 		},
 		'tag': 'd2l-link',
 		'type': 'Navigation'
@@ -371,11 +371,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/list#d2l-list',
 		'development': {
 			'state': 'default',
-			'text': 'in progress'
+			'text': 'In progress'
 		},
 		'design': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'tag': 'd2l-list',
 		'type': 'Structure'
@@ -384,11 +384,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/list#d2l-list-item',
 		'development': {
 			'state': 'default',
-			'text': 'in progress'
+			'text': 'In progress'
 		},
 		'design': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'tag': 'd2l-list-item',
 		'type': 'Structure'
@@ -397,11 +397,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/list#d2l-list-content',
 		'development': {
 			'state': 'default',
-			'text': 'in progress'
+			'text': 'In progress'
 		},
 		'design': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'tag': 'd2l-list-content',
 		'type': 'Structure'
@@ -410,11 +410,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/loading-spinner',
 		'development': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'design': {
 			'state': 'alert',
-			'text': 'incomplete'
+			'text': 'No design'
 		},
 		'tag': 'd2l-loading-spinner',
 		'type': 'Feedback'
@@ -426,11 +426,11 @@ export default [
 			'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/menu#d2l-menu',
 			'development': {
 				'state': 'success',
-				'text': 'complete'
+				'text': 'Complete'
 			},
 			'design': {
 				'state': 'success',
-				'text': 'complete'
+				'text': 'Complete'
 			},
 			'tag': 'd2l-menu',
 			'type': 'Actions'
@@ -439,11 +439,11 @@ export default [
 			'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/menu#d2l-menu-item',
 			'development': {
 				'state': 'success',
-				'text': 'complete'
+				'text': 'Complete'
 			},
 			'design': {
 				'state': 'success',
-				'text': 'complete'
+				'text': 'Complete'
 			},
 			'tag': 'd2l-menu-item',
 			'type': 'Actions'
@@ -452,11 +452,11 @@ export default [
 			'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/menu#d2l-menu-item-link',
 			'development': {
 				'state': 'success',
-				'text': 'complete'
+				'text': 'Complete'
 			},
 			'design': {
 				'state': 'alert',
-				'text': 'incomplete'
+				'text': 'No design'
 			},
 			'tag': 'd2l-menu-item-link',
 			'type': 'Actions'
@@ -465,11 +465,11 @@ export default [
 			'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/menu#d2l-menu-item-checkbox',
 			'development': {
 				'state': 'success',
-				'text': 'complete'
+				'text': 'Complete'
 			},
 			'design': {
 				'state': 'alert',
-				'text': 'incomplete'
+				'text': 'No design'
 			},
 			'tag': 'd2l-menu-item-checkbox',
 			'type': 'Actions'
@@ -478,11 +478,11 @@ export default [
 			'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/menu#d2l-menu-item-radio',
 			'development': {
 				'state': 'success',
-				'text': 'complete'
+				'text': 'Complete'
 			},
 			'design': {
 				'state': 'alert',
-				'text': 'incomplete'
+				'text': 'No design'
 			},
 			'tag': 'd2l-menu-item-radio',
 			'type': 'Actions'
@@ -492,11 +492,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/meter#d2l-meter-linear',
 		'development': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'design': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'tag': 'd2l-meter-linear',
 		'type': 'Other'
@@ -505,11 +505,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/meter#d2l-meter-radial',
 		'development': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'design': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'tag': 'd2l-meter-radial',
 		'type': 'Other'
@@ -518,11 +518,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/meter#d2l-meter-circle',
 		'development': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'design': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'tag': 'd2l-meter-circle',
 		'type': 'Other'
@@ -531,11 +531,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/more-less#more-less',
 		'development': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'design': {
 			'state': 'alert',
-			'text': 'incomplete'
+			'text': 'No design'
 		},
 		'tag': 'd2l-more-less',
 		'type': 'Structure'
@@ -544,11 +544,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/navigation#d2l-navigation',
 		'development': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'design': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'tag': 'd2l-navigation',
 		'type': 'Navigation'
@@ -557,11 +557,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/navigation#d2l-navigation-immersive',
 		'development': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'design': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'tag': 'd2l-navigation-immersive',
 		'type': 'Navigation'
@@ -570,11 +570,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/offscreen#off-screen-content',
 		'development': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'design': {
 			'state': 'alert',
-			'text': 'incomplete'
+			'text': 'No design'
 		},
 		'tag': 'd2l-offscreen',
 		'type': 'Structure'
@@ -583,11 +583,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceHypermediaComponents/users',
 		'development': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'design': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'tag': 'd2l-profile-image',
 		'type': 'Other'
@@ -596,11 +596,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/facet-filter-sort#d2l-filter-dropdown',
 		'development': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'design': {
 			'state': 'alert',
-			'text': 'incomplete'
+			'text': 'No design'
 		},
 		'tag': 'd2l-filter-dropdown',
 		'type': 'Actions'
@@ -609,11 +609,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/facet-filter-sort#d2l-applied-filters',
 		'development': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'design': {
 			'state': 'alert',
-			'text': 'incomplete'
+			'text': 'No design'
 		},
 		'tag': 'd2l-applied-filters',
 		'type': 'Actions'
@@ -621,12 +621,12 @@ export default [
 		'name': 'Sort Dropdown',
 		'readme': 'https://github.com/BrightspaceUI/facet-filter-sort#d2l-sort-by-dropdown',
 		'development': {
-			'state': 'default',
-			'text': 'out of date'
+			'state': 'action',
+			'text': 'Out of date'
 		},
 		'design': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'tag': 'd2l-sort-by-dropdown',
 		'type': 'Actions'
@@ -634,12 +634,12 @@ export default [
 		'name': 'Search Facets',
 		'readme': 'https://github.com/BrightspaceUI/facet-filter-sort#d2l-search-facets',
 		'development': {
-			'state': 'default',
-			'text': 'out of date'
+			'state': 'action',
+			'text': 'Out of date'
 		},
 		'design': {
 			'state': 'alert',
-			'text': 'incomplete'
+			'text': 'No design'
 		},
 		'tag': 'd2l-search-facets',
 		'type': 'Actions'
@@ -647,12 +647,12 @@ export default [
 		'name': 'Search Results Count',
 		'readme': 'https://github.com/BrightspaceUI/facet-filter-sort#d2l-search-results-count',
 		'development': {
-			'state': 'default',
-			'text': 'out of date'
+			'state': 'action',
+			'text': 'Out of date'
 		},
 		'design': {
 			'state': 'alert',
-			'text': 'incomplete'
+			'text': 'No design'
 		},
 		'tag': 'd2l-search-results-count',
 		'type': 'Actions'
@@ -660,12 +660,12 @@ export default [
 		'name': 'Status Indicator',
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/status-indicator#d2l-status-indicator',
 		'development': {
-			'state': 'default',
-			'text': 'out of date'
+			'state': 'action',
+			'text': 'Out of date'
 		},
 		'design': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'tag': 'd2l-status-indicator',
 		'type': 'Feedback'
@@ -674,11 +674,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/table#d2l-table',
 		'development': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'design': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'tag': 'd2l-table',
 		'type': 'Structure'
@@ -687,11 +687,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/tabs#d2l-tabs',
 		'development': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'design': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'tag': 'd2l-tabs',
 		'type': 'Structure'
@@ -700,11 +700,11 @@ export default [
 		'readme': 'https://github.com/BrightspaceUI/core/tree/master/components/tooltip#d2l-tooltip',
 		'development': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'design': {
 			'state': 'success',
-			'text': 'complete'
+			'text': 'Complete'
 		},
 		'tag': 'd2l-tooltip',
 		'type': 'Feedback'

--- a/src/component-list.js
+++ b/src/component-list.js
@@ -2,7 +2,6 @@ import '@brightspace-ui/core/components/colors/colors.js';
 import '@brightspace-ui/core/components/icons/icon.js';
 import '@brightspace-ui/core/components/inputs/input-search.js';
 import '@brightspace-ui/core/components/link/link.js';
-import '@brightspace-ui/core/components/status-indicator/status-indicator.js';
 import 'd2l-table/d2l-table.js';
 import { bodySmallStyles, heading2Styles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html, LitElement } from 'lit-element';
@@ -36,10 +35,6 @@ export class DesignSystemComponentList extends LitElement {
 
 			d2l-table {
 				padding-top: 1rem;
-			}
-
-			d2l-link d2l-status-indicator {
-				cursor: pointer;
 			}
 
 			d2l-icon {

--- a/src/component-list.js
+++ b/src/component-list.js
@@ -1,10 +1,12 @@
+import '@brightspace-ui/core/components/colors/colors.js';
+import '@brightspace-ui/core/components/icons/icon.js';
 import '@brightspace-ui/core/components/inputs/input-search.js';
 import '@brightspace-ui/core/components/link/link.js';
 import '@brightspace-ui/core/components/status-indicator/status-indicator.js';
 import 'd2l-table/d2l-table.js';
+import { bodySmallStyles, heading2Styles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html, LitElement } from 'lit-element';
 import { default as components } from '../data/components.js';
-import { heading2Styles } from '@brightspace-ui/core/components/typography/styles.js';
 import { tableStyles } from './table-styles.js';
 
 export class DesignSystemComponentList extends LitElement {
@@ -15,7 +17,7 @@ export class DesignSystemComponentList extends LitElement {
 	}
 
 	static get styles() {
-		return [heading2Styles, tableStyles, css`
+		return [bodySmallStyles, heading2Styles, tableStyles, css`
 			:host {
 				display: block;
 			}
@@ -39,6 +41,30 @@ export class DesignSystemComponentList extends LitElement {
 			d2l-link d2l-status-indicator {
 				cursor: pointer;
 			}
+
+			d2l-icon {
+				padding-right: 0.3rem;
+			}
+
+			d2l-icon[data-state="action"] {
+				color: var(--d2l-color-feedback-warning);
+			}
+
+			d2l-icon[data-state="alert"] {
+				color: var(--d2l-color-feedback-error);
+			}
+
+			d2l-icon[data-state="default"] {
+				color: var(--d2l-color-feedback-action);
+			}
+
+			d2l-icon[data-state="success"] {
+				color: var(--d2l-color-feedback-success);
+			}
+
+			.d2l-design-system-component-list-info-text {
+				display: inline-block;
+			}
 		`];
 	}
 
@@ -55,24 +81,24 @@ export class DesignSystemComponentList extends LitElement {
 			if (this._filter && !component.name.toLowerCase().includes(this._filter.toLowerCase())) return null;
 			if (component.childComponents) {
 				return component.childComponents.map((childComponent) => {
-					const baseState = html`<d2l-status-indicator state="${childComponent.development.state}" text="${childComponent.development.text}"></d2l-status-indicator>`;
-					const state = childComponent.readme ? html`<d2l-link href="${childComponent.readme}">${baseState}</d2l-link>` : baseState;
+					const devState = this._getStateMessage(childComponent.development, childComponent.readme);
+					const designState = this._getStateMessage(childComponent.design);
 					return html`
 						<d2l-tr>
 							<d2l-td><d2l-link href="/components/${component.name}/${childComponent.tag}">${childComponent.name}</d2l-link></d2l-td>
-							<d2l-td>${state}</d2l-td>
-							<d2l-td><d2l-status-indicator state="${childComponent.design.state}" text="${childComponent.design.text}"></d2l-status-indicator></d2l-td>
+							<d2l-td>${devState}</d2l-td>
+							<d2l-td>${designState}</d2l-td>
 						</d2l-tr>
 					`;
 				});
 			} else {
-				const baseState = html`<d2l-status-indicator state="${component.development.state}" text="${component.development.text}"></d2l-status-indicator>`;
-				const state = component.readme ? html`<d2l-link href="${component.readme}">${baseState}</d2l-link>` : baseState;
+				const devState = this._getStateMessage(component.development, component.readme);
+				const designState = this._getStateMessage(component.design);
 				return html`
 					<d2l-tr>
 						<d2l-td><d2l-link href="/components/${component.tag}">${component.name}</d2l-link></d2l-td>
-						<d2l-td>${state}</d2l-td>
-						<d2l-td><d2l-status-indicator state="${component.design.state}" text="${component.design.text}"></d2l-status-indicator></d2l-td>
+						<d2l-td>${devState}</d2l-td>
+						<d2l-td>${designState}</d2l-td>
 					</d2l-tr>
 				`;
 			}
@@ -93,6 +119,25 @@ export class DesignSystemComponentList extends LitElement {
 				</d2l-tbody>
 			</d2l-table>
 		`;
+	}
+
+	_getStateMessage(componentStateInfo, readme) {
+		let icon = 'tier1:important';
+		switch (componentStateInfo.state) {
+			case 'action':
+				icon = 'tier1:important';
+				break;
+			case 'alert':
+				icon = 'tier1:close-default';
+				break;
+			case 'success':
+				icon = 'tier1:check';
+				break;
+		}
+		const stateText = readme
+			? html`<d2l-link small href="${readme}">${componentStateInfo.text}</d2l-link>`
+			: html`<div class="d2l-body-small d2l-design-system-component-list-info-text">${componentStateInfo.text}`;
+		return html`<d2l-icon data-state="${componentStateInfo.state}" icon="${icon}"></d2l-icon>${stateText}`;
 	}
 }
 customElements.define('d2l-design-system-component-list', DesignSystemComponentList);

--- a/src/component-list.js
+++ b/src/component-list.js
@@ -8,6 +8,25 @@ import { css, html, LitElement } from 'lit-element';
 import { default as components } from '../data/components.js';
 import { tableStyles } from './table-styles.js';
 
+function _getStateMessage(componentStateInfo, readme) {
+	let icon = 'tier1:important';
+	switch (componentStateInfo.state) {
+		case 'action':
+			icon = 'tier1:important';
+			break;
+		case 'alert':
+			icon = 'tier1:close-default';
+			break;
+		case 'success':
+			icon = 'tier1:check';
+			break;
+	}
+	const stateText = readme
+		? html`<d2l-link small href="${readme}">${componentStateInfo.text}</d2l-link>`
+		: html`<div class="d2l-body-small d2l-design-system-component-list-info-text">${componentStateInfo.text}</div>`;
+	return html`<d2l-icon data-state="${componentStateInfo.state}" icon="${icon}"></d2l-icon>${stateText}`;
+}
+
 export class DesignSystemComponentList extends LitElement {
 	static get properties() {
 		return {
@@ -76,8 +95,8 @@ export class DesignSystemComponentList extends LitElement {
 			if (this._filter && !component.name.toLowerCase().includes(this._filter.toLowerCase())) return null;
 			if (component.childComponents) {
 				return component.childComponents.map((childComponent) => {
-					const devState = this._getStateMessage(childComponent.development, childComponent.readme);
-					const designState = this._getStateMessage(childComponent.design);
+					const devState = _getStateMessage(childComponent.development, childComponent.readme);
+					const designState = _getStateMessage(childComponent.design);
 					return html`
 						<d2l-tr>
 							<d2l-td><d2l-link href="/components/${component.name}/${childComponent.tag}">${childComponent.name}</d2l-link></d2l-td>
@@ -87,8 +106,8 @@ export class DesignSystemComponentList extends LitElement {
 					`;
 				});
 			} else {
-				const devState = this._getStateMessage(component.development, component.readme);
-				const designState = this._getStateMessage(component.design);
+				const devState = _getStateMessage(component.development, component.readme);
+				const designState = _getStateMessage(component.design);
 				return html`
 					<d2l-tr>
 						<d2l-td><d2l-link href="/components/${component.tag}">${component.name}</d2l-link></d2l-td>
@@ -114,25 +133,6 @@ export class DesignSystemComponentList extends LitElement {
 				</d2l-tbody>
 			</d2l-table>
 		`;
-	}
-
-	_getStateMessage(componentStateInfo, readme) {
-		let icon = 'tier1:important';
-		switch (componentStateInfo.state) {
-			case 'action':
-				icon = 'tier1:important';
-				break;
-			case 'alert':
-				icon = 'tier1:close-default';
-				break;
-			case 'success':
-				icon = 'tier1:check';
-				break;
-		}
-		const stateText = readme
-			? html`<d2l-link small href="${readme}">${componentStateInfo.text}</d2l-link>`
-			: html`<div class="d2l-body-small d2l-design-system-component-list-info-text">${componentStateInfo.text}</div>`;
-		return html`<d2l-icon data-state="${componentStateInfo.state}" icon="${icon}"></d2l-icon>${stateText}`;
 	}
 }
 customElements.define('d2l-design-system-component-list', DesignSystemComponentList);

--- a/src/component-list.js
+++ b/src/component-list.js
@@ -136,7 +136,7 @@ export class DesignSystemComponentList extends LitElement {
 		}
 		const stateText = readme
 			? html`<d2l-link small href="${readme}">${componentStateInfo.text}</d2l-link>`
-			: html`<div class="d2l-body-small d2l-design-system-component-list-info-text">${componentStateInfo.text}`;
+			: html`<div class="d2l-body-small d2l-design-system-component-list-info-text">${componentStateInfo.text}</div>`;
 		return html`<d2l-icon data-state="${componentStateInfo.state}" icon="${icon}"></d2l-icon>${stateText}`;
 	}
 }


### PR DESCRIPTION
Switched from status indicator to icon + link (if readme link) or icon + text (if no link) in order to make it more clear that there is a link present