### PR TITLE
switching to use site structure data to lay out the site

### DIFF
--- a/data/structure.js
+++ b/data/structure.js
@@ -1,0 +1,131 @@
+import { default as components } from '../data/components.js';
+
+const siteStructure = [
+	{
+		name: 'Welcome',
+		type: 'custom'
+	},
+	{
+		name: 'Component Status',
+		type: 'custom'
+	},
+	{
+		name: 'Actions',
+		type: 'container'
+	},
+	{
+		name: 'Feedback',
+		type: 'container'
+	},
+	{
+		name: 'Overlay',
+		type: 'container'
+	},
+	{
+		name: 'Navigation',
+		type: 'container'
+	},
+	{
+		name: 'Structure',
+		type: 'container'
+	},
+	{
+		name: 'Forms',
+		type: 'container'
+	},
+	{
+		name: 'Other',
+		type: 'container'
+	}
+];
+components.forEach((component) => {
+	let cat = siteStructure.find((c) => c.name === component.type);
+	if (!cat) {
+		cat = { name: component.type };
+		siteStructure.push(cat);
+	}
+	cat.children = cat.children || [];
+	cat.children.push(convertComponentToItem(component));
+});
+
+function convertComponentToItem(component) {
+	const item = { name: component.name, type: 'component', children: [], data: { tagName: component.tag } };
+	if (component.childComponents) {
+		item.type = 'container';
+		item.children = component.childComponents.map((c) => convertComponentToItem(c));
+	}
+	return item;
+}
+
+function makeUrlFriendly(name) {
+	return name.replace(/\s/g, '-').toLowerCase();
+}
+
+export function findItemFromPath(path) {
+	function search(items, parents) {
+		for (let i = 0; i < items.length; i++) {
+			const item = items[i];
+			parents.push(item);
+			const itemPath = `/components/${parents.map((p) => makeUrlFriendly(p.name)).join('/')}`;
+			if (itemPath === path) {
+				return item;
+			}
+			if (item.children) {
+				const result = search(item.children, parents);
+				if (result !== null) {
+					return result;
+				}
+			}
+			parents.pop();
+		}
+		return null;
+	}
+	return search(siteStructure, []);
+}
+
+export function getComponentPathFromTagName(tagName) {
+	function search(items) {
+		for (let i = 0; i < items.length; i++) {
+			const item = items[i];
+			if (item.type === 'component' && item.data.tagName === tagName) {
+				return getItemPath(item).realPath;
+			}
+			if (item.children) {
+				const result = search(item.children);
+				if (result !== null) {
+					return result;
+				}
+			}
+		}
+		return null;
+	}
+	return search(siteStructure);
+}
+
+export function getItemPath(searchItem) {
+	function search(items, parents) {
+		for (let i = 0; i < items.length; i++) {
+			const item = items[i];
+			parents.push(item);
+			if (searchItem === item) {
+				const realPath = `/components/${parents.map((p) => makeUrlFriendly(p.name)).join('/')}`;
+				let itemPath = realPath;
+				if (item.type === 'container' && item.children.length > 0) {
+					itemPath += `/${makeUrlFriendly(item.children[0].name)}`;
+				}
+				return {path: itemPath, realPath: realPath};
+			}
+			if (item.children) {
+				const result = search(item.children, parents);
+				if (result !== null) {
+					return result;
+				}
+			}
+			parents.pop();
+		}
+		return null;
+	}
+	return search(siteStructure, []);
+}
+
+export { siteStructure };

--- a/src/app.js
+++ b/src/app.js
@@ -20,6 +20,10 @@ function buildSidebarItem(item, parents, currentPath) {
 
 	const itemPath = getItemPath(item);
 	const selected = `${currentPath}/`.indexOf(`${itemPath.realPath}/`) === 0;
+	const hasChildren = (item.children && item.children.length > 0);
+	const listItemClasses = {
+		'd2l-design-system-nested': (hasChildren && parents.length === 2)
+	};
 
 	let link = null;
 	if (parents.length === 1) {
@@ -34,7 +38,7 @@ function buildSidebarItem(item, parents, currentPath) {
 	}
 
 	let children = null;
-	if (item.children && item.children.length > 0) {
+	if (hasChildren) {
 		if (parents.length === 1) {
 			children = html`<ul ?hidden="${!selected}">
 				${item.children.map(child => buildSidebarItem(child, parents, currentPath))}
@@ -54,7 +58,7 @@ function buildSidebarItem(item, parents, currentPath) {
 	parents.pop();
 
 	return html`
-		<li>${link}${children}</li>
+		<li class="${classMap(listItemClasses)}">${link}${children}</li>
 	`;
 }
 

--- a/src/component-list.js
+++ b/src/component-list.js
@@ -6,6 +6,7 @@ import 'd2l-table/d2l-table.js';
 import { bodySmallStyles, heading2Styles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html, LitElement } from 'lit-element';
 import { default as components } from '../data/components.js';
+import { getComponentPathFromTagName } from '../data/structure.js';
 import { tableStyles } from './table-styles.js';
 
 function _getStateMessage(componentStateInfo, readme) {
@@ -99,7 +100,7 @@ export class DesignSystemComponentList extends LitElement {
 					const designState = _getStateMessage(childComponent.design);
 					return html`
 						<d2l-tr>
-							<d2l-td><d2l-link href="/components/${component.name}/${childComponent.tag}">${childComponent.name}</d2l-link></d2l-td>
+							<d2l-td><d2l-link href="${getComponentPathFromTagName(childComponent.tag)}">${childComponent.name}</d2l-link></d2l-td>
 							<d2l-td>${devState}</d2l-td>
 							<d2l-td>${designState}</d2l-td>
 						</d2l-tr>
@@ -110,7 +111,7 @@ export class DesignSystemComponentList extends LitElement {
 				const designState = _getStateMessage(component.design);
 				return html`
 					<d2l-tr>
-						<d2l-td><d2l-link href="/components/${component.tag}">${component.name}</d2l-link></d2l-td>
+						<d2l-td><d2l-link href="${getComponentPathFromTagName(component.tag)}">${component.name}</d2l-link></d2l-td>
 						<d2l-td>${devState}</d2l-td>
 						<d2l-td>${designState}</d2l-td>
 					</d2l-tr>

--- a/src/component.js
+++ b/src/component.js
@@ -42,9 +42,7 @@ function _getTable(componentInformation, title, hasTypeAndDefault) {
 export class DesignSystemComponent extends LitElement {
 	static get properties() {
 		return {
-			component: { type: String },
-			_componentInfo: { type: Object },
-			_componentName: { type: String }
+			tagName: { type: String, attribute: 'tag-name', reflect: true }
 		};
 	}
 
@@ -68,23 +66,22 @@ export class DesignSystemComponent extends LitElement {
 		`];
 	}
 
-	constructor() {
-		super();
-
-		this.component = '';
-		this._componentInfo = {};
-	}
-
 	render() {
-		if (!this._componentInfo) return html`<h1 class="d2l-heading-2">${this._componentName}</h1>`;
 
-		const description = this._componentInfo.description ? html`<h2 class="d2l-heading-4">Description:</h2><div>${this._componentInfo.description}</div>` : null;
-		const attributes = this._componentInfo.attributes ? _getTable(this._componentInfo.attributes, 'Attributes', true) : null;
-		const events = this._componentInfo.events ? _getTable(this._componentInfo.events, 'Events') : null;
-		const slots = this._componentInfo.slots ? _getTable(this._componentInfo.slots, 'Slots') : null;
+		const componentInfo = components.find((component) =>  component.name === this.tagName);
+		if (!componentInfo) {
+			// TODO: create a 404 view that we can return
+			console.error(`Could not find component ${this.tagName}`);
+			return;
+		}
+
+		const description = componentInfo.description ? html`<h2 class="d2l-heading-4">Description:</h2><div>${componentInfo.description}</div>` : null;
+		const attributes = componentInfo.attributes ? _getTable(componentInfo.attributes, 'Attributes', true) : null;
+		const events = componentInfo.events ? _getTable(componentInfo.events, 'Events') : null;
+		const slots = componentInfo.slots ? _getTable(componentInfo.slots, 'Slots') : null;
 
 		return html`
-			<h1 class="d2l-heading-2">${this._componentName}</h1>
+			<h1 class="d2l-heading-2">${componentInfo.name}</h1>
 			${description}
 			${attributes}
 			${events}
@@ -92,17 +89,5 @@ export class DesignSystemComponent extends LitElement {
 		`;
 	}
 
-	updated(changedProperties) {
-		super.updated(changedProperties);
-
-		changedProperties.forEach((_, prop) => {
-			if (prop === 'component') {
-				const parsed = JSON.parse(this.component);
-				this._componentName = parsed.name;
-				const filtered = components.filter((component) =>  component.name === parsed.tag);
-				this._componentInfo = filtered[0];
-			}
-		});
-	}
 }
 customElements.define('d2l-design-system-component', DesignSystemComponent);


### PR DESCRIPTION
Alright, finally got something not-crazy-big that didn't break everything you had working. :)

Basically this introduces a `structure.js` that outlines the structure of the site's section. We could add another level of navigation at the top using this later if we want. Each entry in the structure is the same -- it has a name, a type, some custom data and possibly children.

The name of each entry plus all its descendants is how the URL gets crafted.

The type can currently be:
- `custom`: which we can use for custom Lit views like the Component Status page
- `container`: basically just a hint to make the URL the URL of the first child
- `component`: a hint so we load the component view
- `??`: future types like Markdown maybe

I think this is enough so that I can try to implement Markdown page types that can be generated from component READMEs (or a combination of multiple READMEs) or just pointed at local Markdown files in the docs repo (which we could use for the Welcome page for example).