### PR TITLE
Component: Add column to attributes table for setting the attribute in future demo

### DIFF
--- a/src/component-attribute-table.js
+++ b/src/component-attribute-table.js
@@ -18,7 +18,7 @@ const validTypes = [
 export class DesignSystemComponentAttributeTable extends LitElement {
 	static get properties() {
 		return {
-			attributes: { type: Array, reflect: true }
+			attributes: { type: String, reflect: true }
 		};
 	}
 
@@ -45,7 +45,8 @@ export class DesignSystemComponentAttributeTable extends LitElement {
 
 	render() {
 		if (!this.attributes) return;
-		const rows = this.attributes.map((info) => {
+		const attributes = JSON.parse(this.attributes);
+		const rows = attributes.map((info) => {
 			const infoDefault = info.default ? info.default.replace(/\\"/g, '') : null;
 			let demoType = info.type;
 			let demoValue = null;
@@ -136,8 +137,7 @@ export class DesignSystemComponentAttributeTable extends LitElement {
 						aria-label="Valid values"
 						@change="${this._onSelectChange}"
 						class="d2l-input-select"
-						data-name="${attributeName}"
-						type="select">
+						data-name="${attributeName}">
 						${optsHtml}
 					</select>
 				`;

--- a/src/component-attribute-table.js
+++ b/src/component-attribute-table.js
@@ -2,6 +2,7 @@ import '@brightspace-ui/core/components/inputs/input-text.js';
 import '@brightspace-ui/core/components/switch/switch.js';
 import 'd2l-table/d2l-table.js';
 import { css, html, LitElement } from 'lit-element';
+import { default as components } from '../data/component-doc-details.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { selectStyles } from '@brightspace-ui/core/components/inputs/input-select-styles.js';
 import { tableStyles } from './table-styles.js';
@@ -18,7 +19,7 @@ const validTypes = [
 export class DesignSystemComponentAttributeTable extends LitElement {
 	static get properties() {
 		return {
-			attributes: { type: String, reflect: true }
+			tagName: { type: String, attribute: 'tag-name', reflect: true }
 		};
 	}
 
@@ -44,9 +45,10 @@ export class DesignSystemComponentAttributeTable extends LitElement {
 	}
 
 	render() {
-		if (!this.attributes) return;
-		const attributes = JSON.parse(this.attributes);
-		const rows = attributes.map((info) => {
+		const componentInfo = components.find((component) =>  component.name === this.tagName);
+		if (!componentInfo) return;
+
+		const rows = componentInfo.attributes.map((info) => {
 			const infoDefault = info.default ? info.default.replace(/\\"/g, '') : null;
 			let demoType = info.type;
 			let demoValue = null;

--- a/src/component-attribute-table.js
+++ b/src/component-attribute-table.js
@@ -1,0 +1,185 @@
+import '@brightspace-ui/core/components/inputs/input-text.js';
+import '@brightspace-ui/core/components/switch/switch.js';
+import 'd2l-table/d2l-table.js';
+import { css, html, LitElement } from 'lit-element';
+import { ifDefined } from 'lit-html/directives/if-defined.js';
+import { selectStyles } from '@brightspace-ui/core/components/inputs/input-select-styles.js';
+import { tableStyles } from './table-styles.js';
+
+const stringValidValuesRe = /\(('.*?'\|?)\)/;
+const validTypes = [
+	'array',
+	'boolean',
+	'number',
+	'object',
+	'string'
+];
+
+export class DesignSystemComponentAttributeTable extends LitElement {
+	static get properties() {
+		return {
+			attributes: { type: Array, reflect: true }
+		};
+	}
+
+	static get styles() {
+		return [selectStyles, tableStyles, css`
+			:host {
+				display: block;
+			}
+
+			:host([hidden]) {
+				display: none;
+			}
+
+			d2l-td.d2l-table-cell-first,
+			d2l-td.d2l-design-system-component-type {
+				white-space: nowrap;
+			}
+
+			d2l-td d2l-input-text {
+				min-width: 200px;
+			}
+		`];
+	}
+
+	render() {
+		if (!this.attributes) return;
+		const rows = this.attributes.map((info) => {
+			const infoDefault = info.default ? info.default.replace(/\\"/g, '') : null;
+			let demoType = info.type;
+			let demoValue = null;
+			const match = info.type ? info.type.match(stringValidValuesRe) : null;
+			if (match && match.length === 2) {
+				demoType = match[1].replace(/\|/g, ' | ');
+				demoValue = this._getDemoValueOptions(demoType, info.name, infoDefault);
+			} else {
+				demoValue = validTypes.includes(demoType) ? this._getDemoValueOptions(demoType, info.name, infoDefault) : null;
+			}
+			return html`
+				<d2l-tr>
+					<d2l-td>${info.name}</d2l-td>
+					<d2l-td>${info.description}</d2l-td>
+					<d2l-td class="d2l-design-system-component-type">${demoType}</d2l-td>
+					<d2l-td>${infoDefault}</d2l-td>
+					<d2l-td>${demoValue}</d2l-td>
+				</d2l-tr>
+			`;
+		});
+		return html`
+			<d2l-table class="d2l-table">
+				<d2l-thead>
+					<d2l-tr>
+						<d2l-th>Name</d2l-th>
+						<d2l-th>Description</d2l-th>
+						<d2l-th>Type</d2l-th>
+						<d2l-th>Default</d2l-th>
+						<d2l-th>Demo Value</d2l-th>
+					</d2l-tr>
+				</d2l-thead>
+				<d2l-tbody>
+					${rows}
+				</d2l-tbody>
+			</d2l-table>
+		`;
+	}
+
+	_dispatchChangeEvent(details) {
+		this.dispatchEvent(new CustomEvent(
+			'change',
+			{ bubbles: true, composed: false, detail: details }
+		));
+		console.warn(`ATTRIBUTE CHANGE: ${JSON.stringify(details)}`);
+	}
+
+	_getDemoValueOptions(type, attributeName, defaultVal) {
+		const value = defaultVal ? defaultVal.replace(/"/g, '') : undefined;
+		switch (type) {
+			case 'array':
+			case 'object':
+				return '';
+			case 'boolean':
+				return html`
+					<d2l-switch
+						@change="${this._onSwitchChange}"
+						data-name="${attributeName}"
+						?on="${value === 'true'}"
+						text="${attributeName}"
+						text-position="hidden">
+					</d2l-switch>
+				`;
+			case 'number':
+				return html`
+					<d2l-input-text
+						@change="${this._onNumberChange}"
+						data-name="${attributeName}"
+						label="${attributeName}"
+						label-hidden
+						value="${ifDefined(value)}">
+					</d2l-input-text>
+				`;
+			case 'string':
+				return html`
+					<d2l-input-text
+						@change="${this._onStringChange}"
+						data-name="${attributeName}"
+						label="${attributeName}"
+						label-hidden
+						value="${ifDefined(value)}">
+					</d2l-input-text>
+				`;
+			default: {
+				// the case of an array of strings
+				const optsHtml = type.replace(/'/g, '').split(' | ').map(opt => html`<option ?selected="${value === opt}">${opt}</option>`);
+				return html`
+					<select
+						aria-label="Valid values"
+						@change="${this._onSelectChange}"
+						class="d2l-input-select"
+						data-name="${attributeName}"
+						type="select">
+						${optsHtml}
+					</select>
+				`;
+			}
+		}
+	}
+
+	_onNumberChange(e) {
+		const eventDetails = {
+			name: e.target.getAttribute('data-name'),
+			type: 'Number',
+			value: e.target.value
+		};
+		this._dispatchChangeEvent(eventDetails);
+	}
+
+	_onSelectChange(e) {
+		const eventDetails = {
+			name: e.target.getAttribute('data-name'),
+			type: 'String',
+			value: e.target.value
+		};
+		this._dispatchChangeEvent(eventDetails);
+	}
+
+	_onStringChange(e) {
+		const eventDetails = {
+			name: e.target.getAttribute('data-name'),
+			type: 'String',
+			value: e.target.value
+		};
+		this._dispatchChangeEvent(eventDetails);
+	}
+
+	_onSwitchChange(e) {
+		const eventDetails = {
+			name: e.target.getAttribute('data-name'),
+			type: 'Boolean',
+			value: e.target.hasAttribute('on')
+		};
+		this._dispatchChangeEvent(eventDetails);
+	}
+
+}
+customElements.define('d2l-design-system-component-attribute-table', DesignSystemComponentAttributeTable);

--- a/src/component.js
+++ b/src/component.js
@@ -68,7 +68,6 @@ export class DesignSystemComponent extends LitElement {
 			console.error(`Could not find component ${this.tagName}`);
 			return;
 		}
-		const attributes = JSON.stringify(componentInfo.attributes);
 		const description = componentInfo.description ? html`<h2 class="d2l-heading-4">Description</h2><div>${componentInfo.description}</div>` : null;
 		const events = componentInfo.events ? _getTable(componentInfo.events, 'Events') : null;
 		const slots = componentInfo.slots ? _getTable(componentInfo.slots, 'Slots') : null;
@@ -77,7 +76,7 @@ export class DesignSystemComponent extends LitElement {
 			<h1 class="d2l-heading-2">${componentInfo.name}</h1>
 			${description}
 			<h2 class="d2l-heading-4">Attributes</h2>
-			<d2l-design-system-component-attribute-table attributes="${attributes}"></d2l-design-system-component-attribute-table>
+			<d2l-design-system-component-attribute-table tag-name="${this.tagName}"></d2l-design-system-component-attribute-table>
 			${events}
 			${slots}
 		`;

--- a/src/component.js
+++ b/src/component.js
@@ -1,27 +1,44 @@
+import '@brightspace-ui/core/components/inputs/input-text.js';
+import '@brightspace-ui/core/components/switch/switch.js';
 import 'd2l-table/d2l-table.js';
 import { css, html, LitElement } from 'lit-element';
 import { heading2Styles, heading4Styles } from '@brightspace-ui/core/components/typography/styles.js';
 import { default as components } from '../data/component-doc-details.js';
+import { ifDefined } from 'lit-html/directives/if-defined.js';
+import { inputLabelStyles } from '@brightspace-ui/core/components/inputs/input-label-styles.js';
+import { selectStyles } from '@brightspace-ui/core/components/inputs/input-select-styles.js';
 import { tableStyles } from './table-styles.js';
 
-function _getTable(componentInformation, title, hasTypeAndDefault) {
+function _getAttributesTable(componentInformation, title, changeFunc) {
+	const stringValidValuesRe = /\(('.*?'\|?)\)/;
+	const validTypes = [
+		'array',
+		'boolean',
+		'number',
+		'object',
+		'string'
+	];
+
 	const rows = componentInformation.map((info) => {
-		const typeDefaultRows = hasTypeAndDefault ? html`
-				<d2l-td>${info.type}</d2l-td>
-				<d2l-td>${info.default}</d2l-td>`
-			: null;
+		const infoDefault = info.default ? info.default.replace(/\\"/g, '') : null;
+		const match = info.type ? info.type.match(stringValidValuesRe) : null;
+		let demoType = info.type;
+		let displayedType = info.type;
+		if (match && match.length === 2) {
+			demoType = match[1];
+			displayedType = 'string';
+		}
+		const demoValue = validTypes.includes(displayedType) ? _getDemoValueOptions(demoType, info.name, changeFunc, infoDefault) : null;
 		return html`
 			<d2l-tr>
 				<d2l-td>${info.name}</d2l-td>
 				<d2l-td>${info.description}</d2l-td>
-				${typeDefaultRows}
+				<d2l-td>${displayedType}</d2l-td>
+				<d2l-td>${infoDefault}</d2l-td>
+				<d2l-td>${demoValue}</d2l-td>
 			</d2l-tr>
 		`;
 	});
-	const typeDefaultHeadings = hasTypeAndDefault ? html`
-			<d2l-th>Type</d2l-th>
-			<d2l-th>Default</d2l-th>`
-		: null;
 	return html`
 		<h2 class="d2l-heading-4">${title}</h2>
 		<d2l-table class="d2l-table">
@@ -29,7 +46,80 @@ function _getTable(componentInformation, title, hasTypeAndDefault) {
 				<d2l-tr>
 					<d2l-th>Name</d2l-th>
 					<d2l-th>Description</d2l-th>
-					${typeDefaultHeadings}
+					<d2l-th>Type</d2l-th>
+					<d2l-th>Default</d2l-th>
+					<d2l-th>Demo Value</d2l-th>
+				</d2l-tr>
+			</d2l-thead>
+			<d2l-tbody>
+				${rows}
+			</d2l-tbody>
+		</d2l-table>
+	`;
+}
+
+function _getDemoValueOptions(type, attributeName, changeFunc, defaultVal) {
+	const value = defaultVal ? defaultVal.replace(/"/g, '') : undefined;
+	switch (type) {
+		case 'array':
+		case 'object':
+			return '';
+		case 'boolean':
+			return html`
+				<d2l-switch
+					@change="${changeFunc}"
+					data-name="${attributeName}"
+					?on="${value === 'true'}"
+					text="${attributeName}"
+					text-position="hidden">
+				</d2l-switch>
+			`;
+		case 'number':
+		case 'string':
+			return html`
+				<d2l-input-text
+					@change="${changeFunc}"
+					data-name="${attributeName}"
+					label="${attributeName}"
+					label-hidden
+					value="${ifDefined(value)}">
+				</d2l-input-text>
+			`;
+		default: {
+			// the case of an array of strings
+			const optsHtml = type.replace(/'/g, '').split('|').map(opt => html`<option>${opt}</option>`);
+			return html`
+				<label>
+					<span class="d2l-input-label">Valid string values</span>
+					<select
+						@change="${changeFunc}"
+						class="d2l-input-select"
+						data-name="${attributeName}"
+						type="select">
+						${optsHtml}
+					</select>
+				</label>
+			`;
+		}
+	}
+}
+
+function _getTable(componentInformation, title) {
+	const rows = componentInformation.map((info) => {
+		return html`
+			<d2l-tr>
+				<d2l-td>${info.name}</d2l-td>
+				<d2l-td>${info.description}</d2l-td>
+			</d2l-tr>
+		`;
+	});
+	return html`
+		<h2 class="d2l-heading-4">${title}</h2>
+		<d2l-table class="d2l-table">
+			<d2l-thead>
+				<d2l-tr>
+					<d2l-th>Name</d2l-th>
+					<d2l-th>Description</d2l-th>
 				</d2l-tr>
 			</d2l-thead>
 			<d2l-tbody>
@@ -47,7 +137,7 @@ export class DesignSystemComponent extends LitElement {
 	}
 
 	static get styles() {
-		return [heading2Styles, heading4Styles, tableStyles, css`
+		return [heading2Styles, heading4Styles, inputLabelStyles, selectStyles, tableStyles, css`
 			:host {
 				display: block;
 			}
@@ -63,6 +153,14 @@ export class DesignSystemComponent extends LitElement {
 			h2.d2l-heading-4 {
 				margin-bottom: 0.3rem;
 			}
+
+			d2l-td.d2l-table-cell-first {
+				white-space: nowrap;
+			}
+
+			d2l-td d2l-input-text {
+				min-width: 200px;
+			}
 		`];
 	}
 
@@ -74,9 +172,8 @@ export class DesignSystemComponent extends LitElement {
 			console.error(`Could not find component ${this.tagName}`);
 			return;
 		}
-
-		const description = componentInfo.description ? html`<h2 class="d2l-heading-4">Description:</h2><div>${componentInfo.description}</div>` : null;
-		const attributes = componentInfo.attributes ? _getTable(componentInfo.attributes, 'Attributes', true) : null;
+		const description = componentInfo.description ? html`<h2 class="d2l-heading-4">Description</h2><div>${componentInfo.description}</div>` : null;
+		const attributes = componentInfo.attributes ? _getAttributesTable(componentInfo.attributes, 'Attributes', this._onChange) : null;
 		const events = componentInfo.events ? _getTable(componentInfo.events, 'Events') : null;
 		const slots = componentInfo.slots ? _getTable(componentInfo.slots, 'Slots') : null;
 
@@ -87,6 +184,12 @@ export class DesignSystemComponent extends LitElement {
 			${events}
 			${slots}
 		`;
+	}
+
+	_onChange(e) {
+		const attributeName = e.target.getAttribute('data-name');
+		const attributeValue = e.target.value || e.target.hasAttribute('on');
+		console.warn(`ATTRIBUTE CHANGE: name: ${attributeName}, value: ${attributeValue}`);
 	}
 
 }

--- a/src/component.js
+++ b/src/component.js
@@ -1,108 +1,9 @@
-import '@brightspace-ui/core/components/inputs/input-text.js';
-import '@brightspace-ui/core/components/switch/switch.js';
+import './component-attribute-table.js';
 import 'd2l-table/d2l-table.js';
 import { css, html, LitElement } from 'lit-element';
 import { heading2Styles, heading4Styles } from '@brightspace-ui/core/components/typography/styles.js';
 import { default as components } from '../data/component-doc-details.js';
-import { ifDefined } from 'lit-html/directives/if-defined.js';
-import { inputLabelStyles } from '@brightspace-ui/core/components/inputs/input-label-styles.js';
-import { selectStyles } from '@brightspace-ui/core/components/inputs/input-select-styles.js';
 import { tableStyles } from './table-styles.js';
-
-function _getAttributesTable(componentInformation, title, changeFunc) {
-	const stringValidValuesRe = /\(('.*?'\|?)\)/;
-	const validTypes = [
-		'array',
-		'boolean',
-		'number',
-		'object',
-		'string'
-	];
-
-	const rows = componentInformation.map((info) => {
-		const infoDefault = info.default ? info.default.replace(/\\"/g, '') : null;
-		const match = info.type ? info.type.match(stringValidValuesRe) : null;
-		let demoType = info.type;
-		let displayedType = info.type;
-		if (match && match.length === 2) {
-			demoType = match[1];
-			displayedType = 'string';
-		}
-		const demoValue = validTypes.includes(displayedType) ? _getDemoValueOptions(demoType, info.name, changeFunc, infoDefault) : null;
-		return html`
-			<d2l-tr>
-				<d2l-td>${info.name}</d2l-td>
-				<d2l-td>${info.description}</d2l-td>
-				<d2l-td>${displayedType}</d2l-td>
-				<d2l-td>${infoDefault}</d2l-td>
-				<d2l-td>${demoValue}</d2l-td>
-			</d2l-tr>
-		`;
-	});
-	return html`
-		<h2 class="d2l-heading-4">${title}</h2>
-		<d2l-table class="d2l-table">
-			<d2l-thead>
-				<d2l-tr>
-					<d2l-th>Name</d2l-th>
-					<d2l-th>Description</d2l-th>
-					<d2l-th>Type</d2l-th>
-					<d2l-th>Default</d2l-th>
-					<d2l-th>Demo Value</d2l-th>
-				</d2l-tr>
-			</d2l-thead>
-			<d2l-tbody>
-				${rows}
-			</d2l-tbody>
-		</d2l-table>
-	`;
-}
-
-function _getDemoValueOptions(type, attributeName, changeFunc, defaultVal) {
-	const value = defaultVal ? defaultVal.replace(/"/g, '') : undefined;
-	switch (type) {
-		case 'array':
-		case 'object':
-			return '';
-		case 'boolean':
-			return html`
-				<d2l-switch
-					@change="${changeFunc}"
-					data-name="${attributeName}"
-					?on="${value === 'true'}"
-					text="${attributeName}"
-					text-position="hidden">
-				</d2l-switch>
-			`;
-		case 'number':
-		case 'string':
-			return html`
-				<d2l-input-text
-					@change="${changeFunc}"
-					data-name="${attributeName}"
-					label="${attributeName}"
-					label-hidden
-					value="${ifDefined(value)}">
-				</d2l-input-text>
-			`;
-		default: {
-			// the case of an array of strings
-			const optsHtml = type.replace(/'/g, '').split('|').map(opt => html`<option>${opt}</option>`);
-			return html`
-				<label>
-					<span class="d2l-input-label">Valid string values</span>
-					<select
-						@change="${changeFunc}"
-						class="d2l-input-select"
-						data-name="${attributeName}"
-						type="select">
-						${optsHtml}
-					</select>
-				</label>
-			`;
-		}
-	}
-}
 
 function _getTable(componentInformation, title) {
 	const rows = componentInformation.map((info) => {
@@ -137,7 +38,7 @@ export class DesignSystemComponent extends LitElement {
 	}
 
 	static get styles() {
-		return [heading2Styles, heading4Styles, inputLabelStyles, selectStyles, tableStyles, css`
+		return [heading2Styles, heading4Styles, tableStyles, css`
 			:host {
 				display: block;
 			}
@@ -154,42 +55,32 @@ export class DesignSystemComponent extends LitElement {
 				margin-bottom: 0.3rem;
 			}
 
-			d2l-td.d2l-table-cell-first {
+			d2l-td.d2l-table-cell-first{
 				white-space: nowrap;
-			}
-
-			d2l-td d2l-input-text {
-				min-width: 200px;
 			}
 		`];
 	}
 
 	render() {
-
 		const componentInfo = components.find((component) =>  component.name === this.tagName);
 		if (!componentInfo) {
 			// TODO: create a 404 view that we can return
 			console.error(`Could not find component ${this.tagName}`);
 			return;
 		}
+		const attributes = JSON.stringify(componentInfo.attributes);
 		const description = componentInfo.description ? html`<h2 class="d2l-heading-4">Description</h2><div>${componentInfo.description}</div>` : null;
-		const attributes = componentInfo.attributes ? _getAttributesTable(componentInfo.attributes, 'Attributes', this._onChange) : null;
 		const events = componentInfo.events ? _getTable(componentInfo.events, 'Events') : null;
 		const slots = componentInfo.slots ? _getTable(componentInfo.slots, 'Slots') : null;
 
 		return html`
 			<h1 class="d2l-heading-2">${componentInfo.name}</h1>
 			${description}
-			${attributes}
+			<h2 class="d2l-heading-4">Attributes</h2>
+			<d2l-design-system-component-attribute-table attributes="${attributes}"></d2l-design-system-component-attribute-table>
 			${events}
 			${slots}
 		`;
-	}
-
-	_onChange(e) {
-		const attributeName = e.target.getAttribute('data-name');
-		const attributeValue = e.target.value || e.target.hasAttribute('on');
-		console.warn(`ATTRIBUTE CHANGE: name: ${attributeName}, value: ${attributeValue}`);
 	}
 
 }


### PR DESCRIPTION
Attributes with type `array` and `object` are not handled as I wasn't totally sure what to do there. Could also do a input-text which contains empty `{}` or `[]` for the user to fill in.

Example (from d2l-tooltip):
<img width="1129" alt="Screen Shot 2020-06-25 at 10 35 47 AM" src="https://user-images.githubusercontent.com/6804600/85740560-b76bc400-b6cf-11ea-81ef-de9144509172.png">
