### PR TITLE
Turn into JS Module

### DIFF
--- a/cli/generate-component-doc-details.js
+++ b/cli/generate-component-doc-details.js
@@ -1,6 +1,9 @@
-const chalk = require('chalk'),
-	fs = require('fs'),
-	path = require('path');
+import chalk from 'chalk';
+import { fileURLToPath } from 'url';
+import fs from 'fs';
+import path from 'path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 function _parseFile(fileName) {
 	const file = fs.readFileSync(fileName).toString();

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "author": "D2L Corporation",
   "license": "Apache-2.0",
+  "type": "module",
   "devDependencies": {
     "@open-wc/building-rollup": "^1",
     "@open-wc/eslint-config": "^2",


### PR DESCRIPTION
This allows us to use `import` in the CLI scripts, which I need to do in order to pull in `structure.js` to generate things. You'll need to be using Node >= 13.9 for this to work.