### PR TITLE
generating a component markdown fille

### DIFF
--- a/data/structure.js
+++ b/data/structure.js
@@ -12,7 +12,18 @@ export const siteStructure = [
 	},
 	{
 		name: 'Actions',
-		type: 'container'
+		type: 'container',
+		children: [
+			{
+				name: 'Button 2',
+				type: 'markdown',
+				subtype: 'component',
+				path: 'pages/components/button2.md',
+				data: {
+					tagName: 'd2l-button'
+				}
+			}
+		]
 	},
 	{
 		name: 'Feedback',

--- a/pages/components/button2.md
+++ b/pages/components/button2.md
@@ -1,0 +1,22 @@
+# d2l-button
+
+The `d2l-button` element can be used just like the native button element, but also supports the `primary` attribute for denoting the primary button.
+
+## Examples
+
+```html
+<script type="module">
+  import '@brightspace-ui/core/components/button/button.js';
+</script>
+<d2l-button>My Button</d2l-button>
+```
+
+## Accessibility
+
+To make your `d2l-button` accessible, use the following properties when applicable:
+
+| Attribute | Description |
+|--|--|
+| `aria-expanded` | [Indicate expansion state of a collapsible element](https://www.w3.org/WAI/PF/aria/states_and_properties#aria-expanded). Example: [d2l-more-less](https://github.com/BrightspaceUI/core/blob/f9f30d0975ee5a8479263a84541fc3b781e8830f/components/more-less/more-less.js#L158). |
+| `aria-haspopup` | [Indicate clicking the button opens a menu](https://www.w3.org/WAI/PF/aria/states_and_properties#aria-haspopup). Example: [d2l-dropdown](https://github.com/BrightspaceUI/core/blob/master/components/dropdown/dropdown-opener-mixin.js#L46). |
+| `description` | Use when text on button does not provide enough context. |

--- a/src/markdown-page.js
+++ b/src/markdown-page.js
@@ -1,3 +1,4 @@
+import './component-attribute-table.js';
 import { css, html, LitElement } from 'lit-element';
 import {loadPage} from '../.generated/pages/pageLoader.js';
 


### PR DESCRIPTION
Building on the previous PR, this creates a dummy "Button2" Markdown file and generates some special markup for it. This could be swapped out with the actual Button's REAMDE.md file once we figure out what format we'd like it to be in.

For now, this is super dumb -- I overrode some things in the renderer to look for a heading called "Examples" and then the next code block after that becomes the interactive one. We could do whatever we want here... and the lexer/parser may be a better place to hook in but I ran out of time.

Next step here would be to hook all this together with core's demo snippet thing... I think we're close-ish!

It might also make sense to have the component READMEs themselves contain some front-matter that tells us where they belong in the site structure... that way we wouldn't need to map every single one like this. But we can sort that out later.