### PR TITLE
Use interactive-demo component in generate instead of attribute-table

### DIFF
--- a/cli/generate.js
+++ b/cli/generate.js
@@ -15,7 +15,7 @@ function createComponentRenderer(tagName) {
 		code(code, infostring, escaped) {
 			if (isExampleBlock) {
 				isExampleBlock = false;
-				return `<d2l-design-system-component-attribute-table tag-name="${tagName}" code="${escape(code)}"></d2l-design-system-component-attribute-table>`;
+				return `<d2l-design-system-interactive-demo code="${escape(code)}" tag-name="${tagName}"></d2l-design-system-interactive-demo>`;
 			}
 			return defaultRenderer.code(code, infostring, escaped);
 		},

--- a/src/component-attribute-table.js
+++ b/src/component-attribute-table.js
@@ -1,6 +1,5 @@
 import '@brightspace-ui/core/components/inputs/input-text.js';
 import '@brightspace-ui/core/components/switch/switch.js';
-import './interactive-demo.js';
 import 'd2l-table/d2l-table.js';
 import { css, html, LitElement } from 'lit-element';
 import { default as components } from '../.generated/component-doc-details.js';
@@ -21,10 +20,8 @@ const validTypes = [
 export class DesignSystemComponentAttributeTable extends LitElement {
 	static get properties() {
 		return {
-			code: { type: String, reflect: true },
 			hideDemo: { type: Boolean, attribute: 'hide-demo', reflect: true },
-			tagName: { type: String, attribute: 'tag-name', reflect: true },
-			_changedAttributes: { type: Object }
+			tagName: { type: String, attribute: 'tag-name', reflect: true }
 		};
 	}
 
@@ -55,7 +52,6 @@ export class DesignSystemComponentAttributeTable extends LitElement {
 
 	constructor() {
 		super();
-		this._changedAttributes = {};
 		this.hideDemo = false;
 	}
 
@@ -74,23 +70,19 @@ export class DesignSystemComponentAttributeTable extends LitElement {
 			} else {
 				demoValue = validTypes.includes(demoType) ? this._getDemoValueOptions(demoType, info.name, infoDefault) : null;
 			}
+			const demoValueRow = !this.hideDemo ? html`<d2l-td>${demoValue}</d2l-td>` : null;
 			return html`
 				<d2l-tr>
 					<d2l-td>${info.name}</d2l-td>
 					<d2l-td>${info.description}</d2l-td>
 					<d2l-td class="d2l-design-system-component-type">${demoType}</d2l-td>
 					<d2l-td>${infoDefault}</d2l-td>
-					<d2l-td>${demoValue}</d2l-td>
+					${demoValueRow}
 				</d2l-tr>
 			`;
 		});
-		const demo = !this.hideDemo ? html`
-			<d2l-design-system-interactive-demo
-				attributes="${JSON.stringify(this._changedAttributes)}"
-				code="${this.code}">
-			</d2l-design-system-interactive-demo>` : null;
+		const demoValueHeading = !this.hideDemo ? html`<d2l-th>Demo Value</d2l-th>` : null;
 		return html`
-			${demo}
 			<h2 class="d2l-heading-4">Attributes</h2>
 			<d2l-table class="d2l-table">
 				<d2l-thead>
@@ -99,7 +91,7 @@ export class DesignSystemComponentAttributeTable extends LitElement {
 						<d2l-th>Description</d2l-th>
 						<d2l-th>Type</d2l-th>
 						<d2l-th>Default</d2l-th>
-						<d2l-th>Demo Value</d2l-th>
+						${demoValueHeading}
 					</d2l-tr>
 				</d2l-thead>
 				<d2l-tbody>
@@ -110,13 +102,10 @@ export class DesignSystemComponentAttributeTable extends LitElement {
 	}
 
 	_dispatchChangeEvent(details) {
-		const tempAttributes = this._changedAttributes;
-		this._changedAttributes = {};
-		tempAttributes[details.name] = {
-			value: details.value,
-			type: details.type
-		};
-		this._changedAttributes = tempAttributes;
+		this.dispatchEvent(new CustomEvent(
+			'change',
+			{ bubbles: true, composed: false, detail: details }
+		));
 	}
 
 	_getDemoValueOptions(type, attributeName, defaultVal) {

--- a/src/interactive-demo.js
+++ b/src/interactive-demo.js
@@ -1,3 +1,4 @@
+import './component-attribute-table.js';
 import '@brightspace-ui/core/components/demo/demo-snippet.js';
 import { css, html, LitElement } from 'lit-element';
 
@@ -5,7 +6,8 @@ export class DesignSystemInteractiveDemo extends LitElement {
 	static get properties() {
 		return {
 			attributes: { type: String, reflect: true },
-			code: { type: String, reflect: true }
+			code: { type: String, reflect: true },
+			tagName: { type: String, attribute: 'tag-name', reflect: true }
 		};
 	}
 
@@ -35,29 +37,12 @@ export class DesignSystemInteractiveDemo extends LitElement {
 
 	render() {
 		return html`
-			<d2l-demo-snippet>
-			</d2l-demo-snippet>
+			<d2l-demo-snippet></d2l-demo-snippet>
+			<d2l-design-system-component-attribute-table
+				@change="${this._onChange}"
+				tag-name="${this.tagName}">
+			</d2l-design-system-component-attribute-table>
 		`;
-	}
-
-	updated(changedProperties) {
-		super.firstUpdated(changedProperties);
-
-		changedProperties.forEach((_, prop) => {
-			if (prop === 'attributes' && this.attributes !== '{}') {
-				const attributes = JSON.parse(this.attributes);
-				const component = this.shadowRoot.querySelector('d2l-demo-snippet').children[0];
-				Object.keys(attributes).forEach((key) => {
-					if (attributes[key].type === 'Boolean') {
-						if (attributes[key].value === false && component.hasAttribute(key)) component.removeAttribute(key);
-						else if (attributes[key].value === true && !component.hasAttribute(key)) component.setAttribute(key, '');
-					} else {
-						component.setAttribute(key, attributes[key].value);
-					}
-				});
-				this.shadowRoot.querySelector('d2l-demo-snippet').forceCodeUpdate();
-			}
-		});
 	}
 
 	async _getCode() {
@@ -80,6 +65,18 @@ export class DesignSystemInteractiveDemo extends LitElement {
 
 		demoSnippet.appendChild(script);
 		demoSnippet.innerHTML = code;
+	}
+
+	_onChange(e) {
+		const component = this.shadowRoot.querySelector('d2l-demo-snippet').children[0];
+		const details = e.detail;
+		if (details.type === 'Boolean') {
+			if (details.value === false && component.hasAttribute(details.name)) component.removeAttribute(details.name);
+			else if (details.value && !component.hasAttribute(details.name)) component.setAttribute(details.name, '');
+		} else {
+			component.setAttribute(details.name, details.value);
+		}
+		this.shadowRoot.querySelector('d2l-demo-snippet').forceCodeUpdate();
 	}
 
 }

--- a/src/markdown-page.js
+++ b/src/markdown-page.js
@@ -1,4 +1,4 @@
-import './component-attribute-table.js';
+import './interactive-demo.js';
 import { css, html, LitElement } from 'lit-element';
 import {loadPage} from '../.generated/pages/pageLoader.js';
 


### PR DESCRIPTION
I also made the demo value column optional for now for pages that aren't yet using markdown.