### PR TITLE
Improve markdown parsing

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -3,6 +3,26 @@ const cleanCSS = require('clean-css');
 const eleventyNavigationPlugin = require('@11ty/eleventy-navigation');
 const { escapeHtml } = require('markdown-it/lib/common/utils');
 
+function _getScript(content) {
+	if (!content.includes('<script')) return '';
+
+	const scriptStart = content.split('</script>');
+	if (scriptStart.length !== 2) return '';
+
+	const scriptContent = scriptStart[0].split('<script type="module">\n');
+	if (scriptContent.length !== 2) return '';
+
+	const importsArray = scriptContent[1].split('\n');
+	let imports = '';
+	importsArray.forEach((importUrl) => {
+		if (importUrl.includes('import ')) {
+			const importStatement = importUrl.replace(/^(.*import.*[\\/])/g, 'import \'/assets/js/'); // replace everything before final backslash
+			imports += `${importStatement}\n`;
+		}
+	});
+	return `<script type="module">${imports}</script>`;
+}
+
 module.exports = function(eleventyConfig) {
 	eleventyConfig.addPassthroughCopy('assets/js');
 	eleventyConfig.addPassthroughCopy('pages/components/imported/screenshots');
@@ -49,19 +69,7 @@ module.exports = function(eleventyConfig) {
 	markdownIt.renderer.rules.fence = (tokens, idx, options, env, slf) => {
 		const content = tokens[idx].content;
 		if (content.includes('<!-- docs: live demo -->') || content.includes('<!-- docs: demo -->')) {
-			let script = '';
-			if (content.includes('script')) {
-				const copy = content;
-				const scriptBeforeAfter = copy.split('</script>\n');
-				let imports = '';
-				const importsArray = scriptBeforeAfter[0].split('<script type="module">\n')[1].split('\n');
-				importsArray.forEach((importUrl) => {
-					const importStatement = importUrl.replace(/^(.*[\\/])/g, 'import \'/assets/js/'); // replace everything before final backslash
-					imports += `${importStatement}\n`;
-				});
-				script = `<script type="module">${imports}</script>`;
-			}
-
+			const script = _getScript(content);
 			if (content.includes('<!-- docs: live demo -->')) return `${script}<d2l-component-catalog-interactive-demo>${escapeHtml(content)}</d2l-component-catalog-interactive-demo>`;
 			else return `${script}<d2l-component-catalog-demo-snippet-wrapper>${escapeHtml(content)}</d2l-component-catalog-demo-snippet-wrapper>`;
 		} else return defaultFenceRule(tokens, idx, options, env, slf);
@@ -77,7 +85,7 @@ module.exports = function(eleventyConfig) {
 		else if (content.includes('<!-- docs: start')) {
 			const splitStart = content.split('<!-- docs: start ');
 			const splitEnd = splitStart[1].split(' -->');
-			const contentClass = `d2l-cc-${splitEnd[0].replace(/ /g, '-')}`;
+			const contentClass = `d2l-component-catalog-${splitEnd[0].replace(/ /g, '-')}`;
 			return `<div class="${contentClass}">`;
 		} else return defaultTextRule(tokens, idx, options, env, slf);
 	};

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,10 +1,12 @@
 /* global require, module */
 const cleanCSS = require('clean-css');
 const eleventyNavigationPlugin = require('@11ty/eleventy-navigation');
-const syntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
+const syntaxHighlight = require('@11ty/eleventy-plugin-syntaxhighlight');
 
+// TODO: imports
 module.exports = function(eleventyConfig) {
 	eleventyConfig.addPassthroughCopy('assets/js');
+	eleventyConfig.addPassthroughCopy('pages/components/imported/screenshots');
 
 	const options = {
 		html: false,
@@ -13,14 +15,18 @@ module.exports = function(eleventyConfig) {
 		modifyToken: (token) => {
 			// TODO: enable table cases after d2l-table is ready
 			switch (token.type) {
+				case 'image': {
+					const src = token.attrGet('src');
+					if (src.includes('../screenshots/'))
+						token.attrObj.src = src.replace(/..\/screenshots/, '/components/imported/screenshots');
+					else if (src.includes('./screenshots/'))
+						token.attrObj.src = src.replace(/.\/screenshots/, '/components/imported/screenshots');
+					break;
+				}
 				case 'link_open': {
 					token.tag = 'd2l-link';
 					const href = token.attrGet('href');
-					let newHref;
-					if (href.includes('.md')) newHref = href.replace(/.md/, '.html');
-					else if (href.includes('../screenshots/')) newHref = href.replace(/..\/screenshots/, '/components/imported/screenshots');
-					else if (href.includes('./screenshots/')) newHref = href.replace(/.\/screenshots/, '/components/imported/screenshots');
-					if (newHref) token.attrObj.href = newHref;
+					if (href.includes('.md')) token.attrObj.href = href.replace(/.md/, '.html');
 					break;
 				}
 				case 'link_close':
@@ -46,8 +52,9 @@ module.exports = function(eleventyConfig) {
 		if (content.includes('<!-- docs: live demo -->'))
 			return `<d2l-design-system-interactive-demo>${content}</d2l-design-system-interactive-demo>`;
 		else if (content.includes('<!-- docs: demo -->'))
-			return `<d2l-demo-snippet>${content}</d2l-demo-snippet>`
-		else return defaultFenceRule(tokens, idx, options, env, slf);
+			return `<d2l-demo-snippet>${content}</d2l-demo-snippet>`;
+		else
+			return defaultFenceRule(tokens, idx, options, env, slf);
 	};
 
 	const defaultTextRule = markdownIt.renderer.rules.text;
@@ -62,7 +69,8 @@ module.exports = function(eleventyConfig) {
 			const splitEnd = splitStart[1].split(' -->');
 			const contentClass = `d2l-cc-${splitEnd[0].replace(/ /g, '-')}`;
 			return `<div class="${contentClass}">`;
-		} else return defaultTextRule(tokens, idx, options, env, slf);
+		} else
+			return defaultTextRule(tokens, idx, options, env, slf);
 	};
 
 	eleventyConfig.addPlugin(eleventyNavigationPlugin);

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -64,8 +64,7 @@ module.exports = function(eleventyConfig) {
 
 			if (content.includes('<!-- docs: live demo -->')) return `${script}<d2l-component-catalog-interactive-demo>${escapeHtml(content)}</d2l-component-catalog-interactive-demo>`;
 			else return `${script}<d2l-component-catalog-demo-snippet-wrapper>${escapeHtml(content)}</d2l-component-catalog-demo-snippet-wrapper>`;
-		} else
-			return defaultFenceRule(tokens, idx, options, env, slf);
+		} else return defaultFenceRule(tokens, idx, options, env, slf);
 	};
 
 	const defaultTextRule = markdownIt.renderer.rules.text;
@@ -80,8 +79,7 @@ module.exports = function(eleventyConfig) {
 			const splitEnd = splitStart[1].split(' -->');
 			const contentClass = `d2l-cc-${splitEnd[0].replace(/ /g, '-')}`;
 			return `<div class="${contentClass}">`;
-		} else
-			return defaultTextRule(tokens, idx, options, env, slf);
+		} else return defaultTextRule(tokens, idx, options, env, slf);
 	};
 
 	eleventyConfig.addPlugin(eleventyNavigationPlugin);

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,6 +1,7 @@
 /* global require, module */
 const cleanCSS = require('clean-css');
 const eleventyNavigationPlugin = require('@11ty/eleventy-navigation');
+const syntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
 
 module.exports = function(eleventyConfig) {
 	eleventyConfig.addPassthroughCopy('assets/js');
@@ -8,14 +9,64 @@ module.exports = function(eleventyConfig) {
 	const options = {
 		html: false,
 		breaks: false,
-		linkify: true
+		linkify: true,
+		modifyToken: (token) => {
+			// TODO: enable table cases after d2l-table is ready
+			switch (token.type) {
+				case 'link_open': {
+					token.tag = 'd2l-link';
+					const href = token.attrGet('href');
+					let newHref;
+					if (href.includes('.md')) newHref = href.replace(/.md/, '.html');
+					else if (href.includes('../screenshots/')) newHref = href.replace(/..\/screenshots/, '/components/imported/screenshots');
+					else if (href.includes('./screenshots/')) newHref = href.replace(/.\/screenshots/, '/components/imported/screenshots');
+					if (newHref) token.attrObj.href = newHref;
+					break;
+				}
+				case 'link_close':
+					token.tag = 'd2l-link';
+					break;
+				// case 'table_open':
+				// 	token.tag = 'd2l-table';
+				// 	break;
+				// case 'table_close':
+				// 	token.tag = 'd2l-table';
+				// 	break;
+			}
+		}
 	};
-	const markdownIt = require('markdown-it')(options);
+	const markdownIt = require('markdown-it')(options).use(require('markdown-it-modify-token'));
 	eleventyConfig.addFilter('cssmin', (code) => {
 		return new cleanCSS({}).minify(code).styles;
 	});
 
+	const defaultFenceRule = markdownIt.renderer.rules.fence;
+	markdownIt.renderer.rules.fence = (tokens, idx, options, env, slf) => {
+		const content = tokens[idx].content;
+		if (content.includes('<!-- docs: live demo -->'))
+			return `<d2l-design-system-interactive-demo>${content}</d2l-design-system-interactive-demo>`;
+		else if (content.includes('<!-- docs: demo -->'))
+			return `<d2l-demo-snippet>${content}</d2l-demo-snippet>`
+		else return defaultFenceRule(tokens, idx, options, env, slf);
+	};
+
+	const defaultTextRule = markdownIt.renderer.rules.text;
+	markdownIt.renderer.rules.text = (tokens, idx, options, env, slf) => {
+		const content = tokens[idx].content;
+		if (content.includes('<!-- docs: start hidden content -->'))
+			return '<div style="display: none;">';
+		else if (content.includes('<!-- docs: end'))
+			return '</div>';
+		else if (content.includes('<!-- docs: start')) {
+			const splitStart = content.split('<!-- docs: start ');
+			const splitEnd = splitStart[1].split(' -->');
+			const contentClass = `d2l-cc-${splitEnd[0].replace(/ /g, '-')}`;
+			return `<div class="${contentClass}">`;
+		} else return defaultTextRule(tokens, idx, options, env, slf);
+	};
+
 	eleventyConfig.addPlugin(eleventyNavigationPlugin);
+	eleventyConfig.addPlugin(syntaxHighlight);
 	eleventyConfig.setUseGitIgnore(false);
 	eleventyConfig.setLibrary('md', markdownIt);
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _site
 assets/
 node_modules/
 package-lock.json
+pages/components/imported/

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "devDependencies": {
     "@11ty/eleventy": "^0.12",
     "@11ty/eleventy-navigation": "^0.1",
-    "@11ty/eleventy-plugin-syntaxhighlight": "^3",
     "@babel/core": "^7",
     "@babel/eslint-parser": "^7",
     "@babel/preset-env": "^7",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@11ty/eleventy": "^0.12",
     "@11ty/eleventy-navigation": "^0.1",
+    "@11ty/eleventy-plugin-syntaxhighlight": "^3",
     "@babel/core": "^7",
     "@babel/eslint-parser": "^7",
     "@babel/preset-env": "^7",
@@ -31,6 +32,7 @@
     "eslint-plugin-lit": "^1",
     "eslint-plugin-sort-class-members": "^1",
     "lit-analyzer": "^1",
+    "markdown-it-modify-token": "^1",
     "npm-run-all": "^4",
     "rimraf": "^3",
     "rollup": "^2"

--- a/pages/_includes/css/prism-ghcolors.css
+++ b/pages/_includes/css/prism-ghcolors.css
@@ -1,0 +1,87 @@
+code[class*="language-"],
+pre[class*="language-"] {
+	font-family: "Consolas", "Bitstream Vera Sans Mono", "Courier New", Courier, monospace;
+	font-size: .9em;
+	line-height: 1.2em;
+	word-break: normal;
+}
+
+pre[class*="language-"] {
+	background-color: white;
+	margin: 0;
+	overflow: auto;
+	padding: 0;
+}
+
+:not(pre) > code {
+	padding: .2em;
+	padding-top: 1px;
+	padding-bottom: 1px;
+	background: var(--d2l-color-sylvite);
+}
+
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+	color: var(--d2l-color-galena);
+}
+
+.token.namespace {
+	opacity: .7;
+}
+
+.token.punctuation,
+.token.operator {
+	color: var(--d2l-color-ferrite);
+}
+
+.token.string,
+.token.attr-value,
+.token.entity,
+.token.url,
+.token.symbol,
+.token.number,
+.token.boolean,
+.token.variable,
+.token.constant,
+.token.property,
+.token.regex,
+.token.inserted {
+	color: var(--d2l-color-celestine-minus-1);
+}
+
+.token.atrule,
+.token.attr-name,
+.language-autohotkey .token.selector {
+	color: var(--d2l-color-celestine);
+}
+
+.token.keyword {
+	color: var(--d2l-color-cinnabar);
+}
+
+.token.function,
+.token.deleted,
+.language-autohotkey .token.tag {
+	color: var(--d2l-color-fluorite-minus-1);
+}
+
+.token.tag,
+.token.selector,
+.language-autohotkey .token.keyword {
+	color: var(--d2l-color-olivine-minus-1)
+}
+
+.token.important,
+.token.bold {
+	font-weight: bold;
+}
+
+.token.italic {
+	font-style: italic;
+}
+
+.token.class-name {
+	color: var(--d2l-color-carnelian);
+}

--- a/pages/_includes/css/prism-ghcolors.css
+++ b/pages/_includes/css/prism-ghcolors.css
@@ -1,23 +1,25 @@
 code[class*="language-"],
 pre[class*="language-"] {
 	font-family: "Consolas", "Bitstream Vera Sans Mono", "Courier New", Courier, monospace;
-	font-size: .9em;
-	line-height: 1.2em;
+	font-size: 0.7rem;
+	line-height: 1.2rem;
 	word-break: normal;
 }
 
 pre[class*="language-"] {
-	background-color: white;
+	background-color: var(--d2l-color-sylvite);
+	border-radius: 0.3rem;
 	margin: 0;
+	max-width: 900px;
 	overflow: auto;
-	padding: 0;
+	padding: 0.5rem;
 }
 
 :not(pre) > code {
-	padding: .2em;
-	padding-top: 1px;
-	padding-bottom: 1px;
 	background: var(--d2l-color-sylvite);
+	border-radius: 0.3rem;
+	font-size: 0.7rem;
+	padding: 0.1rem 0.2rem;
 }
 
 .token.comment,
@@ -28,7 +30,7 @@ pre[class*="language-"] {
 }
 
 .token.namespace {
-	opacity: .7;
+	opacity: 0.7;
 }
 
 .token.punctuation,
@@ -73,6 +75,10 @@ pre[class*="language-"] {
 	color: var(--d2l-color-olivine-minus-1)
 }
 
+.token.class-name {
+	color: var(--d2l-color-carnelian);
+}
+
 .token.important,
 .token.bold {
 	font-weight: bold;
@@ -80,8 +86,4 @@ pre[class*="language-"] {
 
 .token.italic {
 	font-style: italic;
-}
-
-.token.class-name {
-	color: var(--d2l-color-carnelian);
 }

--- a/pages/_includes/css/style.css
+++ b/pages/_includes/css/style.css
@@ -39,7 +39,7 @@ li {
 ul ul {
 	padding-left: 0.8rem;
 }
-li .d2l-link.d2l-component-catalog-link-selected {
+li d2l-link.d2l-component-catalog-link-selected {
 	border-left: 4px solid var(--d2l-color-celestine-minus-1);
 	color: var(--d2l-color-celestine-minus-1);
 	padding: 0.15rem 0 0.15rem 0.3rem;

--- a/pages/_includes/css/style.css
+++ b/pages/_includes/css/style.css
@@ -1,3 +1,9 @@
+html {
+	font-size: 20px;
+}
+body {
+	margin: 0;
+}
 header {
 	align-items: center;
 	background-color: white;
@@ -8,9 +14,6 @@ header {
 	position: sticky;
 	top: 0;
 	z-index: 1000;
-}
-body {
-	margin: 0;
 }
 main {
 	display: flex;
@@ -33,7 +36,10 @@ li {
 	list-style-type: none;
 	padding-bottom: 1rem;
 }
-li.d2l-component-catalog-link-selected .d2l-link {
+ul ul {
+	padding-left: 0.8rem;
+}
+li .d2l-link.d2l-component-catalog-link-selected {
 	border-left: 4px solid var(--d2l-color-celestine-minus-1);
 	color: var(--d2l-color-celestine-minus-1);
 	padding: 0.15rem 0 0.15rem 0.3rem;

--- a/pages/_includes/layouts/base.njk
+++ b/pages/_includes/layouts/base.njk
@@ -1,6 +1,9 @@
 {% set css %}
 	{% include "css/style.css" %}
 {% endset %}
+{% set codeCss %}
+	{% include "css/prism-ghcolors.css" %}
+{% endset %}
 <!doctype html>
 <html lang="en">
 <head>
@@ -9,6 +12,9 @@
 	<title>{{ eleventyNavigation.title }}</title>
 	<style>
 		{{ css | cssmin | safe }}
+	</style>
+	<style>
+		{{ codeCss | cssmin | safe }}
 	</style>
 	<script src="/assets/js/base-imports.js" type="module"></script>
 </head>
@@ -23,13 +29,13 @@
 			<nav aria-label="Component Information">
 				{% set navPages = collections.all | eleventyNavigation %}
 				{% macro renderNavListItem(entry) -%}
-					<li{% if entry.url == page.url %} class="d2l-component-catalog-link-selected"{% endif %}>
-					<d2l-link href="{{ entry.url | url }}" class="d2l-link">{{ entry.title }}</d2l-link>
-					{%- if entry.children.length -%}
-					<ul>
-						{%- for child in entry.children %}{{ renderNavListItem(child) }}{% endfor -%}
-					</ul>
-					{%- endif -%}
+					<li>
+						<d2l-link href="{{ entry.url | url }}" {% if entry.url == page.url %} class="d2l-component-catalog-link-selected d2l-link"{% endif %} class="d2l-link">{{ entry.title }}</d2l-link>
+						{%- if entry.children.length -%}
+						<ul>
+							{%- for child in entry.children %}{{ renderNavListItem(child) }}{% endfor -%}
+						</ul>
+						{%- endif -%}
 					</li>
 				{%- endmacro %}
 

--- a/pages/_includes/layouts/base.njk
+++ b/pages/_includes/layouts/base.njk
@@ -1,7 +1,5 @@
 {% set css %}
 	{% include "css/style.css" %}
-{% endset %}
-{% set codeCss %}
 	{% include "css/prism-ghcolors.css" %}
 {% endset %}
 <!doctype html>
@@ -12,9 +10,6 @@
 	<title>{{ eleventyNavigation.title }}</title>
 	<style>
 		{{ css | cssmin | safe }}
-	</style>
-	<style>
-		{{ codeCss | cssmin | safe }}
 	</style>
 	<script src="/assets/js/base-imports.js" type="module"></script>
 </head>
@@ -30,7 +25,7 @@
 				{% set navPages = collections.all | eleventyNavigation %}
 				{% macro renderNavListItem(entry) -%}
 					<li>
-						<d2l-link href="{{ entry.url | url }}" {% if entry.url == page.url %} class="d2l-component-catalog-link-selected d2l-link"{% endif %} class="d2l-link">{{ entry.title }}</d2l-link>
+						<d2l-link href="{{ entry.url | url }}" {% if entry.url == page.url %} class="d2l-component-catalog-link-selected"{% endif %}>{{ entry.title }}</d2l-link>
 						{%- if entry.children.length -%}
 						<ul>
 							{%- for child in entry.children %}{{ renderNavListItem(child) }}{% endfor -%}

--- a/pages/_includes/layouts/component.njk
+++ b/pages/_includes/layouts/component.njk
@@ -1,0 +1,6 @@
+---
+layout: layouts/base
+permalink: components/{{eleventyNavigation.parent}}/{{eleventyNavigation.key}}.html
+---
+{{ content | safe }}
+<script src="/assets/js/demo-snippet-wrapper.js" type="module"></script>

--- a/pages/components/example-component.md
+++ b/pages/components/example-component.md
@@ -1,0 +1,52 @@
+---
+layout: layouts/component
+keywords:
+  - button
+eleventyNavigation:
+  key: button
+  title: Button
+  parent: components
+---
+
+# Button
+
+## d2l-button
+
+The `d2l-button` element can be used just like the native button element, but also supports the `primary` attribute for denoting the primary button.
+
+Demo:
+```html
+<!-- docs: demo -->
+<script type="module">
+  import '@brightspace-ui/core/components/button/button.js';
+</script>
+<d2l-button>My Button</d2l-button>
+```
+
+Code block:
+``` html
+<script type="module">
+  import '@brightspace-ui/core/components/button/button.js';
+</script>
+<d2l-button>My Button</d2l-button>
+```
+
+**Accessibility:**
+
+To make your `d2l-button` accessible, use the following properties when applicable:
+
+| Attribute | Description |
+|--|--|
+| `aria-expanded` | [Indicate expansion state of a collapsible element](https://www.w3.org/WAI/PF/aria/states_and_properties#aria-expanded). Example: [d2l-more-less](https://github.com/BrightspaceUI/core/blob/f9f30d0975ee5a8479263a84541fc3b781e8830f/components/more-less/more-less.js#L158). |
+| `aria-haspopup` | [Indicate clicking the button opens a menu](https://www.w3.org/WAI/PF/aria/states_and_properties#aria-haspopup). Example: [d2l-dropdown](https://github.com/BrightspaceUI/core/blob/master/components/dropdown/dropdown-opener-mixin.js#L46). |
+| `description` | Use when text on button does not provide enough context. |
+
+<!-- docs: start hidden content -->
+**Hidden Content:**
+
+You should not see me!
+
+| Test | Table |
+|--|--|
+| hello | I'm not here |
+<!-- docs: end hidden content -->

--- a/pages/components/example-component.md
+++ b/pages/components/example-component.md
@@ -14,6 +14,8 @@ eleventyNavigation:
 
 The `d2l-button` element can be used just like the native button element, but also supports the `primary` attribute for denoting the primary button.
 
+![Button](./screenshots/button.png?raw=true)
+
 Demo:
 ```html
 <!-- docs: demo -->
@@ -33,6 +35,7 @@ Code block:
 
 **Accessibility:**
 
+<!-- docs: start accessibility info -->
 To make your `d2l-button` accessible, use the following properties when applicable:
 
 | Attribute | Description |
@@ -40,6 +43,7 @@ To make your `d2l-button` accessible, use the following properties when applicab
 | `aria-expanded` | [Indicate expansion state of a collapsible element](https://www.w3.org/WAI/PF/aria/states_and_properties#aria-expanded). Example: [d2l-more-less](https://github.com/BrightspaceUI/core/blob/f9f30d0975ee5a8479263a84541fc3b781e8830f/components/more-less/more-less.js#L158). |
 | `aria-haspopup` | [Indicate clicking the button opens a menu](https://www.w3.org/WAI/PF/aria/states_and_properties#aria-haspopup). Example: [d2l-dropdown](https://github.com/BrightspaceUI/core/blob/master/components/dropdown/dropdown-opener-mixin.js#L46). |
 | `description` | Use when text on button does not provide enough context. |
+<!-- docs: end accessibility info -->
 
 <!-- docs: start hidden content -->
 **Hidden Content:**

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,9 @@ import { createBasicConfig } from '@open-wc/building-rollup';
 import merge from 'deepmerge';
 
 const componentFiles = [
-	'./src/base-imports.js'
+	'./node_modules/@brightspace-ui/core/components/button/button.js',
+	'./src/base-imports.js',
+	'./src/demo-snippet-wrapper.js'
 ];
 
 const baseConfig = createBasicConfig({

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,7 @@ import { createBasicConfig } from '@open-wc/building-rollup';
 import merge from 'deepmerge';
 
 const componentFiles = [
-	'./node_modules/@brightspace-ui/core/components/button/button.js',
+	'./node_modules/@brightspace-ui/core/components/button/button.js', // TODO: remove once actual component docs are added
 	'./src/base-imports.js',
 	'./src/demo-snippet-wrapper.js'
 ];

--- a/src/demo-snippet-wrapper.js
+++ b/src/demo-snippet-wrapper.js
@@ -24,10 +24,8 @@ class ComponentCatalogDemoSnippetWrapper extends LitElement {
 		if (!e.target) return;
 		const slotContent = e.target.assignedNodes({ flatten: true })[0];
 		if (!slotContent) return;
-		const code = slotContent.data;
-		const unescaped = unescape(code);
 		const demoSnippet = this.shadowRoot.querySelector('d2l-demo-snippet');
-		demoSnippet.innerHTML = unescaped;
+		demoSnippet.innerHTML = unescape(slotContent.data);
 	}
 
 }

--- a/src/demo-snippet-wrapper.js
+++ b/src/demo-snippet-wrapper.js
@@ -1,0 +1,34 @@
+import '@brightspace-ui/core/components/demo/demo-snippet.js';
+import { css, html, LitElement } from 'lit-element';
+
+class ComponentCatalogDemoSnippetWrapper extends LitElement {
+
+	static get styles() {
+		return css`
+			:host {
+				display: block;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+		`;
+	}
+
+	render() {
+		return html`
+			<d2l-demo-snippet><slot @slotchange="${this._getCode}"></slot></d2l-demo-snippet>
+		`;
+	}
+
+	async _getCode(e) {
+		if (!e.target) return;
+		const slotContent = e.target.assignedNodes({ flatten: true })[0];
+		if (!slotContent) return;
+		const code = slotContent.data;
+		const unescaped = unescape(code);
+		const demoSnippet = this.shadowRoot.querySelector('d2l-demo-snippet');
+		demoSnippet.innerHTML = unescaped;
+	}
+
+}
+customElements.define('d2l-component-catalog-demo-snippet-wrapper', ComponentCatalogDemoSnippetWrapper);


### PR DESCRIPTION
Implements the following:
- Replaces image src with correct path for screenshots
- Replaces link with `d2l-link`
- Parses demos and wraps them in corresponding component wrapper (`d2l-component-catalog-interactive-demo` does not yet exist)
- Handles hidden content and other types of sections (wraps them in a div with corresponding class)
- Uses Daylight colours for syntax highlighting that is similar to GitHub
- Adds an example component to demonstrate some of these parsing abilities