### PR TITLE
Fix small amount of white background showing on right side of main panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint": "^7",
     "eslint-config-brightspace": "^0.14",
     "eslint-plugin-html": "^6",
-    "eslint-plugin-lit": "^1",
+    "eslint-plugin-lit": "~1.4.1",
     "eslint-plugin-sort-class-members": "^1",
     "gray-matter": "^4",
     "lit-analyzer": "^1",

--- a/pages/_includes/css/style.css
+++ b/pages/_includes/css/style.css
@@ -44,7 +44,7 @@ div.d2l-component-catalog-content {
 .d2l-component-catalog-content {
 	background: var(--d2l-color-regolith);
 	flex: 1 1 auto;
-	max-width: calc(78% - 15rem);
+	max-width: calc(79% - 15rem);
 	padding: 4.5rem 7.5rem;
 }
 .d2l-component-catalog-content h1.d2l-heading-1,


### PR DESCRIPTION
The side panel has a flex basis of 21% so this being 78% rather than 79% caused that small amount of white space.