### PR TITLE
Switch subtitle parsing to use square brackets

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -94,14 +94,11 @@ module.exports = function(eleventyConfig) {
 	const defaultTextRule = markdownIt.renderer.rules.text;
 	markdownIt.renderer.rules.text = (tokens, idx, options, env, slf) => {
 		const content = tokens[idx].content;
-		// Note: if tags are formatted like eleventyNavigation then we get error "entry.data.tags is not iterable" when parsing
 		const subTitleMatch = content.match(/\[(.*?)\]/);
 		if (subTitleMatch) {
 			const subtitleMarkdown = subTitleMatch[0];
-			// remove the squire brackets
-			const tag = subtitleMarkdown.slice(1, -1);
-			// Get the rest of the title to add back to the document
-			tokens[idx].content = content.split(subtitleMarkdown).join('');
+			const tag = subtitleMarkdown.slice(1, -1); // remove the square brackets
+			tokens[idx].content = content.split(subtitleMarkdown).join(''); // Get the rest of the title to add back to the document
 			return `
 				${defaultTextRule(tokens, idx, options, env, slf)}
 				<div class="d2l-component-catalog-tag d2l-body-standard">

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -95,8 +95,13 @@ module.exports = function(eleventyConfig) {
 	markdownIt.renderer.rules.text = (tokens, idx, options, env, slf) => {
 		const content = tokens[idx].content;
 		// Note: if tags are formatted like eleventyNavigation then we get error "entry.data.tags is not iterable" when parsing
-		if (env.tags && Object.keys(env.tags[0]).includes(content)) {
-			const tag = env.tags[0][content];
+		const subTitleMatch = content.match(/\[(.*?)\]/);
+		if (subTitleMatch) {
+			const subtitleMarkdown = subTitleMatch[0];
+			// remove the squire brackets
+			const tag = subtitleMarkdown.slice(1, -1);
+			// Get the rest of the title to add back to the document
+			tokens[idx].content = content.split(subtitleMarkdown).join('');
 			return `
 				${defaultTextRule(tokens, idx, options, env, slf)}
 				<div class="d2l-component-catalog-tag d2l-body-standard">

--- a/.github/ISSUE_TEMPLATE/component-documented.md
+++ b/.github/ISSUE_TEMPLATE/component-documented.md
@@ -15,9 +15,6 @@ eleventyNavigation:
   key: <component name, lower case and hyphenated (e.g., menu-item)>
   title: <component name, capitalized (e.g., Menu Item)>
   parent: <component type>
-tags:
-  - <Document Heading (e.g., Button)>: <tag name (e.g., d2l-button)>
-    <Document Heading 2>: <tag name 2>
 ---
 
 repo: "<url>"

--- a/pages/demo.md
+++ b/pages/demo.md
@@ -4,7 +4,7 @@ layout: layouts/demo
 
 # Component Catalogue - Demo Page
 
-### Interactive demo - Includes text variations for coloring
+### Interactive demo - Includes text variations for coloring [demo-snippet]
 
 ```html
 <!-- docs: live demo name:d2l-button -->

--- a/test/generate-pages-utils.test.mjs
+++ b/test/generate-pages-utils.test.mjs
@@ -84,13 +84,9 @@ describe('generate-pages', () => {
 			issueBase.body = `<!--
 ---
 layout: layouts/component
-tags:
-  - Component 1: d2l-component-1
-    Component 2: d2l-component-2
 ---
 -->`;
 			expectedFrontMatter.layout = 'layouts/component';
-			expectedFrontMatter.tags = [{ 'Component 1': 'd2l-component-1', 'Component 2': 'd2l-component-2' }];
 			assert.deepEqual(parseBody(issueBase), { frontMatter: expectedFrontMatter, info: expectedInfo, issueBody: '' });
 		});
 


### PR DESCRIPTION
This would allow us to remove the tags included in the github issue and parse the subtitle based on square brackets: `[subtitle-text]`. I was thinking maybe it is just best to use the formatting `<subtitle-text>` since that is essentially what is going to get rendered in the end. 

Let me know what you think of this approach, I read through a bit of documentation on markdownIt but not sure if its a best practice to edit the tokens.content. 

This also allows us to still include links as it doesn't match with `[text](link)`