### PR TITLE
Docs: create component page

### DIFF
--- a/.github/ISSUE_TEMPLATE/component-documented.md
+++ b/.github/ISSUE_TEMPLATE/component-documented.md
@@ -14,9 +14,9 @@ devMarkdown: "<markdown file path (e.g., README.md)>"
 keywords:
   - <possible search terms>
 eleventyNavigation:
-  key: <component name, lower case and hyphenated (e.g., menu-item)>
-  title: <component name, capitalized (e.g., Menu Item)>
-  parent: <component type>
+  key: <component name, lower case and hyphenated (e.g., menu-item), used as page basename in url>
+  title: <component name, capitalized (e.g., Menu Item), used as title in navigation>
+  parent: <component type, lower case and hyphenated (e.g. actions), used for navigation hierarchy>
 tags:
   - <Document Heading (e.g., Button)>: <tag name (e.g., d2l-button)>
     <Document Heading 2>: <tag name 2>

--- a/README.md
+++ b/README.md
@@ -40,3 +40,11 @@ npx mocha './test/**/*.visual-diff.js' -t 10000 --require esm -g some-pattern
 # update visual-diff goldens
 npx mocha './test/**/*.visual-diff.js' -t 10000 --require esm --golden
 ```
+
+## Requesting a Component
+
+If the component you are interested in has not yet been created or requested, complete the ["Component - Request" issue template](https://github.com/BrightspaceUI/documentation/issues/new?assignees=&labels=Requested+Component&template=component-request.md&title=%3CComponent+Name%3E).
+
+## Creating Documentation
+
+[Adding a component](docs/adding-component.md)

--- a/docs/adding-component.md
+++ b/docs/adding-component.md
@@ -1,0 +1,137 @@
+# Adding a Component
+
+Components with pages in the Daylight site are generally those that are considered official components. These component pages are generated from the component's README.
+
+Other components that are a work in progress have pages that are generated from their issue in this repo.
+
+The main pieces of adding a component page to the Daylight site for an official component are:
+- [Preparing the component](#preparing-the-component) (in the component's repo)
+- [Creating the component issue](#creating-the-component-issue) (in this repo)
+
+## Preparing the Component
+
+### Component Code
+
+Add JSDOC comments to your components. See [input-text](https://github.com/BrightspaceUI/core/blob/master/components/inputs/input-text.js) as an example. Include each of the following where applicable:
+- Description
+- `@slot` (slots)
+- `@fires` (events)
+- Properties descriptions and `@type` if needed (see `type` property in `input-text`)
+
+### Generating custom-elements.json
+
+1. Ensure your `release.yml` GitHub action has a step that generates custom-elements.json. For example:
+```
+- name: Create custom-elements.json
+  run: npx wca analyze \"{components,templates}/**/*.js\" --format json --outFile custom-elements.json
+```
+2. In `package.json` add `custom-elements.json` to `"files"` array.
+
+### README/Markdown Document
+
+1. Remove `properties`, `slots`, and `events` sections. Rename `Accessibility` section to `Accessible Properties`.
+2. Order the document as follows:
+- Title
+- Description
+- Demo with code hidden that displays all components within that page (e.g., for Button page would should all button versions such as regular, subtle, icon). See [Code Blocks](#code-blocks).
+- Design content (could include Best Practices (see [Best Practices](#best-practices)), Accessibility, and Responsive Behaviour)
+- Component heading with tag beside it (e.g., `## Button [d2l-button]`)
+- Live demo (see [Code Blocks](#code-blocks))
+- Any other content that should appear in the document, potentially also including a secondary demo or other code block (see [Code Blocks](#code-blocks)).
+- Content that should not appear in the Daylight site (see [Hidden Content](#hidden-content))
+
+#### Best Practices
+
+The content of the best practices section should be formatted as:
+```
+<!-- docs: start best practices -->
+<!-- docs: start dos -->
+* Do this
+<!-- docs: end dos -->
+
+<!-- docs: start donts -->
+* Don't do that
+<!-- docs: end donts -->
+<!-- docs: end best practices -->
+```
+
+#### Code Blocks
+
+Code-hidden demo: This demo shows only the visual portion of the component(s) without the code. It is generally used at the top of a component page.
+Add the comment `<!-- docs: demo -->` within the code block. For example:
+```
+```html
+<!-- docs: demo -->
+<script type="module">
+  import '@brightspace-ui/core/components/button/button.js';
+</script>
+<d2l-button></d2l-button>
+\`\`\`
+```
+
+Interactive demo (maximum of 1 per component): This demo includes the properties, slots, and events tables, and allows for the user to modify properties in these table(s) which then affects the demo.
+Add the comment `<!-- docs: live demo -->` within the code block at the top and `$attributes` on the component tag. For example:
+```
+```html
+<!-- docs: live demo
+name:<component-tag, e.g., d2l-button>
+size:<'small'|'medium'|'large'|'xlarge'>
+-->
+<script type="module">
+  import '@brightspace-ui/core/components/button/button.js';
+</script>
+<d2l-button $attributes></d2l-button>
+\`\`\`
+```
+
+Secondary demo: This demo shows the component(s) and the code but does not allow any modification. This can be used to show different varients of a component but should be used sporadically generally in order to call out significant varients.
+Add the comment `<!-- docs: code demo -->` within the code block at the top. For example:
+```
+```html
+<!-- docs: code demo -->
+<script type="module">
+  import '@brightspace-ui/core/components/button/button.js';
+</script>
+<d2l-button></d2l-button>
+\`\`\`
+```
+
+Other code blocks with no docs comment will be rendered as code blocks.
+
+#### Hidden Content
+
+This includes information such as installation instructions and testing instructions. Wrap tese sections in `<!-- docs: start hidden content -->` and `<!-- docs: end hidden content -->`. For example:
+
+```
+<!-- docs: start hidden content -->
+**Testing Information**
+This section should not appear in the component catalog.
+<!-- docs: end hidden content -->
+```
+
+### Tips
+
+- Be careful with any relative urls for links or screenshots in the file.
+- Screenshots (minimize number of these is possible) should be stored in a `./screenshots` directory in your repo in order to be copied over correctly.
+
+## Creating the Component Issue
+
+### Requested Component
+
+If you have a component idea that you would like to suggest then you can [submit a GitHub issue](https://github.com/BrightspaceUI/documentation/issues/new?assignees=&labels=Requested+Component&template=component-request.md&title=%3CComponent+Name%3E) for it.
+
+### Labs Component
+
+Labs components generally do not have complete documentation pages in the Daylight site, but do appear in the Status table and also have pages generated from their issues. To document these, [use the GitHub issue template](https://github.com/BrightspaceUI/documentation/issues/new?assignees=&labels=Labs+Component&template=component-in-progress.md&title=%3CComponent+Name%3E).
+
+### Official Component
+
+Once the [Preparing the Component](#preparing-the-component) steps have been completed, [open a GitHub issue](https://github.com/BrightspaceUI/documentation/issues/new?assignees=&labels=Official+Component&template=component-documented.md&title=%3CComponent+Name%3E).
+
+Notes:
+- Open the issue then close it if documentation and development are complete.
+- If the component is ready for the production site, add the `Published` label. This will open a PR so that you can preview the component's page.
+- `eleventyNavigation`:
+	- `key`: Used for the file's basename in the url (since we might want it to be different than the filename)
+	- `title`: Title that appears in the navigation and as the page title. Should correspond to markdown H1.
+	- `parent`: Parent in website hierarychy. Likely corresponds to type. Casing does matter.

--- a/docs/adding-component.md
+++ b/docs/adding-component.md
@@ -22,10 +22,10 @@ Add JSDoc comments to your component. See [input-text](https://github.com/Bright
 
 The `custom-elements.json` file is used for the component's properties, slots, and events.
 
-1. Ensure the `release.yml` GitHub action has a step that generates c`ustom-elements.json`. For example:
+1. Ensure the `release.yml` GitHub action has a step that generates `custom-elements.json`. For example:
 ```
 - name: Create custom-elements.json
-  run: npx wca analyze \"{components,templates}/**/*.js\" --format json --outFile custom-elements.json
+  run: npx wca analyze \"src/*.js\" --format json --outFile custom-elements.json
 ```
 2. In `package.json` add `custom-elements.json` to `"files"` array.
 

--- a/docs/adding-component.md
+++ b/docs/adding-component.md
@@ -1,10 +1,10 @@
-# Adding a Component
+# Adding a Component to the Site
 
 Components with pages in the Daylight site are generally those that are considered official components. These component pages are generated from the component's README.
 
-Other components that are a work in progress have pages that are generated from their issue in this repo.
+Other components that are a work in progress have pages that are generated from their issue in this repo. If the component is not considered an official component then follow the steps mentioned in [Creating the Component Issue](#creating-the-component-issue) for the component type.
 
-The main pieces of adding a component page to the Daylight site for an official component are:
+The main steps to add a component page to the Daylight site for an **official component** are:
 - [Preparing the component](#preparing-the-component) (in the component's repo)
 - [Creating the component issue](#creating-the-component-issue) (in this repo)
 
@@ -12,7 +12,7 @@ The main pieces of adding a component page to the Daylight site for an official 
 
 ### Component Code
 
-Add JSDOC comments to your components. See [input-text](https://github.com/BrightspaceUI/core/blob/master/components/inputs/input-text.js) as an example. Include each of the following where applicable:
+Add JSDoc comments to your component. See [input-text](https://github.com/BrightspaceUI/core/blob/master/components/inputs/input-text.js) as an example. Include each of the following where applicable:
 - Description
 - `@slot` (slots)
 - `@fires` (events)
@@ -20,7 +20,9 @@ Add JSDOC comments to your components. See [input-text](https://github.com/Brigh
 
 ### Generating custom-elements.json
 
-1. Ensure your `release.yml` GitHub action has a step that generates custom-elements.json. For example:
+The `custom-elements.json` file is used for the component's properties, slots, and events.
+
+1. Ensure the `release.yml` GitHub action has a step that generates c`ustom-elements.json`. For example:
 ```
 - name: Create custom-elements.json
   run: npx wca analyze \"{components,templates}/**/*.js\" --format json --outFile custom-elements.json
@@ -39,6 +41,7 @@ Add JSDOC comments to your components. See [input-text](https://github.com/Brigh
 - Live demo (see [Code Blocks](#code-blocks))
 - Any other content that should appear in the document, potentially also including a secondary demo or other code block (see [Code Blocks](#code-blocks)).
 - Content that should not appear in the Daylight site (see [Hidden Content](#hidden-content))
+3. When these changes are merged, ensure a release happens in order for the Daylight site to pick up the changes.
 
 #### Best Practices
 
@@ -57,7 +60,8 @@ The content of the best practices section should be formatted as:
 
 #### Code Blocks
 
-Code-hidden demo: This demo shows only the visual portion of the component(s) without the code. It is generally used at the top of a component page.
+**Code-hidden demo:** This demo shows only the visual portion of the component(s) without the code. It is generally used at the top of a component page.
+
 Add the comment `<!-- docs: demo -->` within the code block. For example:
 ```
 ```html
@@ -69,7 +73,8 @@ Add the comment `<!-- docs: demo -->` within the code block. For example:
 \`\`\`
 ```
 
-Interactive demo (maximum of 1 per component): This demo includes the properties, slots, and events tables, and allows for the user to modify properties in these table(s) which then affects the demo.
+**Interactive demo**: (maximum of 1 per component) This demo includes the properties, slots, and events tables, and allows for the user to modify properties in these table(s) which then affects the demo.
+
 Add the comment `<!-- docs: live demo -->` within the code block at the top and `$attributes` on the component tag. For example:
 ```
 ```html
@@ -84,7 +89,8 @@ size:<'small'|'medium'|'large'|'xlarge'>
 \`\`\`
 ```
 
-Secondary demo: This demo shows the component(s) and the code but does not allow any modification. This can be used to show different varients of a component but should be used sporadically generally in order to call out significant varients.
+**Secondary demo:** This demo shows the component(s) and the code but does not allow any modification. This can be used to show different varients of a component but should be used sporadically generally in order to call out significant varients.
+
 Add the comment `<!-- docs: code demo -->` within the code block at the top. For example:
 ```
 ```html
@@ -96,11 +102,11 @@ Add the comment `<!-- docs: code demo -->` within the code block at the top. For
 \`\`\`
 ```
 
-Other code blocks with no docs comment will be rendered as code blocks.
+**Code blocks:** Other code blocks with no docs comment will be rendered as code blocks.
 
 #### Hidden Content
 
-This includes information such as installation instructions and testing instructions. Wrap tese sections in `<!-- docs: start hidden content -->` and `<!-- docs: end hidden content -->`. For example:
+This includes information such as installation and testing instructions. Wrap these sections in `<!-- docs: start hidden content -->` and `<!-- docs: end hidden content -->`. For example:
 
 ```
 <!-- docs: start hidden content -->
@@ -118,7 +124,7 @@ This section should not appear in the component catalog.
 
 ### Requested Component
 
-If you have a component idea that you would like to suggest then you can [submit a GitHub issue](https://github.com/BrightspaceUI/documentation/issues/new?assignees=&labels=Requested+Component&template=component-request.md&title=%3CComponent+Name%3E) for it.
+If you have a component idea that you would like to suggest then you can [submit a GitHub issue](https://github.com/BrightspaceUI/documentation/issues/new?assignees=&labels=Requested+Component&template=component-request.md&title=%3CComponent+Name%3E) for it. These component requests will appear in the Daylight site in the status pages, and will have pages generated from their issues.
 
 ### Labs Component
 

--- a/docs/adding-component.md
+++ b/docs/adding-component.md
@@ -35,7 +35,7 @@ The `custom-elements.json` file is used for the component's properties, slots, a
 2. Order the document as follows:
 - Title
 - Description
-- Demo with code hidden that displays all components within that page (e.g., for Button page would should all button versions such as regular, subtle, icon). See [Code Blocks](#code-blocks).
+- Demo with code hidden that displays a preview of all components described within that page (e.g., for the Button page it would show all button versions such as regular, subtle, icon). See [Code Blocks](#code-blocks).
 - Design content (could include Best Practices (see [Best Practices](#best-practices)), Accessibility, and Responsive Behaviour)
 - Component heading with tag beside it (e.g., `## Button [d2l-button]`)
 - Live demo (see [Code Blocks](#code-blocks))
@@ -65,7 +65,9 @@ The content of the best practices section should be formatted as:
 Add the comment `<!-- docs: demo -->` within the code block. For example:
 ```
 ```html
-<!-- docs: demo -->
+<!-- docs: demo
+size:<'small'|'medium'|'large'|'xlarge'>
+-->
 <script type="module">
   import '@brightspace-ui/core/components/button/button.js';
 </script>
@@ -94,7 +96,9 @@ size:<'small'|'medium'|'large'|'xlarge'>
 Add the comment `<!-- docs: code demo -->` within the code block at the top. For example:
 ```
 ```html
-<!-- docs: code demo -->
+<!-- docs: code demo
+size:<'small'|'medium'|'large'|'xlarge'>
+-->
 <script type="module">
   import '@brightspace-ui/core/components/button/button.js';
 </script>
@@ -135,9 +139,5 @@ Labs components generally do not have complete documentation pages in the Daylig
 Once the [Preparing the Component](#preparing-the-component) steps have been completed, [open a GitHub issue](https://github.com/BrightspaceUI/documentation/issues/new?assignees=&labels=Official+Component&template=component-documented.md&title=%3CComponent+Name%3E).
 
 Notes:
-- Open the issue then close it if documentation and development are complete.
+- Issues in the documentation repository should be closed if documentation and development are complete.
 - If the component is ready for the production site, add the `Published` label. This will open a PR so that you can preview the component's page.
-- `eleventyNavigation`:
-	- `key`: Used for the file's basename in the url (since we might want it to be different than the filename)
-	- `title`: Title that appears in the navigation and as the page title. Should correspond to markdown H1.
-	- `parent`: Parent in website hierarychy. Likely corresponds to type. Casing does matter.


### PR DESCRIPTION
This documents the process for adding a component (mostly of the official type) to the site. I will also work on a doc for designers to reference on updating markdown files but I'll do that separately.