### PR TITLE
Code parsing: move comment to before code block

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -102,22 +102,25 @@ module.exports = function(eleventyConfig) {
 	const defaultHtmlRule = markdownIt.renderer.rules.html_block;
 	markdownIt.renderer.rules.html_block = (tokens, idx, options, env, slf) => {
 		const content = tokens[idx].content;
-		if (content.includes('<!-- docs: live demo')) {
+		if (content.includes('<!-- docs: demo')) {
 			inCodeBlock = true;
-			const tag = parseConfigurationValue('name', content);
-			if (!tag) return '<d2l-component-catalog-demo-snippet resizable hide-code>';
+			let openingTag = '<d2l-component-catalog-demo-snippet resizable ';
 			const size = parseConfigurationValue('size', content);
-			const defaults = parseConfigurationValue('defaults', content, true);
-			let openingTag = `<d2l-component-catalog-demo-snippet resizable interactive tag-name="${tag}" `;
 			if (size) openingTag += ` size="${size}" `;
-			if (defaults) openingTag += ` defaults='${defaults}'`;
-			return `${openingTag}>`;
-		} else if (content.includes('<!-- docs: code demo -->')) {
-			inCodeBlock = true;
-			return '<d2l-component-catalog-demo-snippet resizable>';
-		} else if (content.includes('<!-- docs: demo -->')) {
-			inCodeBlock = true;
-			return '<d2l-component-catalog-demo-snippet resizable hide-code>';
+
+			if (content.includes('<!-- docs: demo live')) {
+				const tag = parseConfigurationValue('name', content);
+				if (!tag) return `${openingTag} hide-code>`;
+
+				openingTag += ` resizable interactive tag-name="${tag}" `;
+				const defaults = parseConfigurationValue('defaults', content, true);
+				if (defaults) openingTag += ` defaults='${defaults}'`;
+				return `${openingTag}>`;
+			} else if (content.includes('<!-- docs: demo code')) {
+				return `${openingTag}>`;
+			} else if (content.includes('<!-- docs: demo')) {
+				return `${openingTag} hide-code>`;
+			}
 		} else if (content.includes('<!-- docs: start hidden content -->'))
 			return '<div style="display: none;">';
 		else if (content.includes('<!-- docs: end'))

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -40,8 +40,9 @@ module.exports = function(eleventyConfig) {
 				}
 				case 'link_open': {
 					token.tag = 'd2l-link';
-					const href = token.attrGet('href');
-					if (href.includes('.md')) token.attrObj.href = href.replace(/.md/, '.html');
+					// TODO: re-add once pages exist in Daylight to be linked to, for now just keep link the same
+					// const href = token.attrGet('href');
+					// if (href.includes('.md')) token.attrObj.href = href.replace(/.md/, '.html');
 					break;
 				}
 				case 'link_close':

--- a/docs/adding-component.md
+++ b/docs/adding-component.md
@@ -62,12 +62,12 @@ The content of the best practices section should be formatted as:
 
 **Code-hidden demo:** This demo shows only the visual portion of the component(s) without the code. It is generally used at the top of a component page.
 
-Add the comment `<!-- docs: demo -->` within the code block. For example:
+Add the comment `<!-- docs: demo -->` directly before the code block. For example:
 ```
-```html
 <!-- docs: demo
 size:<'small'|'medium'|'large'|'xlarge'>
 -->
+```html
 <script type="module">
   import '@brightspace-ui/core/components/button/button.js';
 </script>
@@ -77,14 +77,14 @@ size:<'small'|'medium'|'large'|'xlarge'>
 
 **Interactive demo**: (maximum of 1 per component) This demo includes the properties, slots, and events tables, and allows for the user to modify properties in these table(s) which then affects the demo.
 
-Add the comment `<!-- docs: live demo -->` within the code block at the top and `$attributes` on the component tag. Note that if `defaults` is being used in order to set default demo values, the demo information pieces must be separated by newlines rather than be inline (e.g., `<!-- docs: live demo name:d2l-button -->`). For example:
+Add the comment `<!-- docs: live demo -->` directly before the code block and `$attributes` on the component tag. Note that if `defaults` is being used in order to set default demo values, the demo information pieces must be separated by newlines rather than be inline (e.g., `<!-- docs: live demo name:d2l-button -->`). For example:
 ```
-```html
 <!-- docs: live demo
 name:<component-tag, e.g., d2l-button>
 size:<'small'|'medium'|'large'|'xlarge'>
 defaults:{"<attribute>": <value: "string"|boolean|number>}>
 -->
+```html
 <script type="module">
   import '@brightspace-ui/core/components/button/button.js';
 </script>
@@ -94,12 +94,12 @@ defaults:{"<attribute>": <value: "string"|boolean|number>}>
 
 **Secondary demo:** This demo shows the component(s) and the code but does not allow any modification. This can be used to show different varients of a component but should be used sporadically generally in order to call out significant varients.
 
-Add the comment `<!-- docs: code demo -->` within the code block at the top. For example:
+Add the comment `<!-- docs: code demo -->` directly before the code block. For example:
 ```
-```html
 <!-- docs: code demo
 size:<'small'|'medium'|'large'|'xlarge'>
 -->
+```html
 <script type="module">
   import '@brightspace-ui/core/components/button/button.js';
 </script>

--- a/docs/adding-component.md
+++ b/docs/adding-component.md
@@ -77,9 +77,9 @@ size:<'small'|'medium'|'large'|'xlarge'>
 
 **Interactive demo**: (maximum of 1 per component) This demo includes the properties, slots, and events tables, and allows for the user to modify properties in these table(s) which then affects the demo.
 
-Add the comment `<!-- docs: live demo -->` directly before the code block and `$attributes` on the component tag. Note that if `defaults` is being used in order to set default demo values, the demo information pieces must be separated by newlines rather than be inline (e.g., `<!-- docs: live demo name:d2l-button -->`). For example:
+Add the comment `<!-- docs: demo live -->` directly before the code block and `$attributes` on the component tag. Note that if `defaults` is being used in order to set default demo values, the demo information pieces must be separated by newlines rather than be inline (e.g., `<!-- docs: demo live name:d2l-button -->`). For example:
 ```
-<!-- docs: live demo
+<!-- docs: demo live
 name:<component-tag, e.g., d2l-button>
 size:<'small'|'medium'|'large'|'xlarge'>
 defaults:{"<attribute>": <value: "string"|boolean|number>}>
@@ -94,9 +94,9 @@ defaults:{"<attribute>": <value: "string"|boolean|number>}>
 
 **Secondary demo:** This demo shows the component(s) and the code but does not allow any modification. This can be used to show different varients of a component but should be used sporadically generally in order to call out significant varients.
 
-Add the comment `<!-- docs: code demo -->` directly before the code block. For example:
+Add the comment `<!-- docs: demo code -->` directly before the code block. For example:
 ```
-<!-- docs: code demo
+<!-- docs: demo code
 size:<'small'|'medium'|'large'|'xlarge'>
 -->
 ```html

--- a/pages/assets/demo-snippet.js
+++ b/pages/assets/demo-snippet.js
@@ -4,8 +4,8 @@ import './demo-resizable-preview.js';
 import 'playground-elements/playground-code-editor';
 import 'prismjs/prism.js';
 import { css, html, LitElement } from 'lit-element';
-import { parseConfigurationValue, parseImports } from './utils.mjs';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
+import { parseImports } from './utils.mjs';
 import { themeStyles } from './code-style.js';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html';
 import { validTypes } from './demo-tables.js';
@@ -13,10 +13,7 @@ import { validTypes } from './demo-tables.js';
 class ComponentCatalogDemoSnippetWrapper extends LitElement {
 	static get properties() {
 		return {
-			/**
-			* Code from the markdown to manipulate before previewing in the IFrame
-			*/
-			demoSnippet:  { type: String, attribute: 'demo-snippet' },
+			defaults: { type: String },
 			/**
 			* Hide the read-only code view
 			*/
@@ -37,6 +34,8 @@ class ComponentCatalogDemoSnippetWrapper extends LitElement {
 			* Is the preview resizable
 			*/
 			resizable : { type: Boolean, reflect: true },
+			size: { type: String },
+			tagName: { attribute: 'tag-name', type: String },
 			_attributes: { type: Object, reflect: true }
 		};
 	}
@@ -81,6 +80,7 @@ class ComponentCatalogDemoSnippetWrapper extends LitElement {
 
 	get code() {
 		// remove comment lines from code snippet
+		if (!this.demoSnippet) return '';
 		const lines = this.demoSnippet.split('-->');
 		const codeSnippet = lines.length === 1 ? lines[0] : lines[1]; // if there was no `-->` found lines[1] will be null
 		if (this.interactive) {
@@ -115,23 +115,8 @@ class ComponentCatalogDemoSnippetWrapper extends LitElement {
 		return codeSnippet;
 	}
 
-	get defaults() {
-		const defaults = parseConfigurationValue('defaults', this.demoSnippet, true);
-		return defaults;
-	}
-
 	get imports() {
 		return parseImports(this.demoSnippet);
-	}
-
-	get size() {
-		const size = parseConfigurationValue('size', this.demoSnippet);
-		return size;
-	}
-
-	get tagName() {
-		const name = parseConfigurationValue('name', this.demoSnippet);
-		return name;
 	}
 
 	connectedCallback() {
@@ -148,6 +133,7 @@ class ComponentCatalogDemoSnippetWrapper extends LitElement {
 	}
 
 	render() {
+		if (!this.demoSnippet) return html`<slot @slotchange="${this._handleSlotChange}"></slot>`;
 		const codeSnippet = this.code;
 
 		return html`
@@ -187,6 +173,14 @@ class ComponentCatalogDemoSnippetWrapper extends LitElement {
 	_handlePropertyChange(event) {
 		this._updateAttributes(event.detail);
 		this.requestUpdate();
+	}
+
+	_handleSlotChange() {
+		const slot = this.shadowRoot.querySelector('slot');
+		if (slot && slot.assignedNodes().length > 0) {
+			this.demoSnippet = slot.assignedNodes()[0].textContent;
+			this._highlightedCodeSnippet = Prism.highlight(this.code, Prism.languages[this.language], this.language);
+		}
 	}
 
 	_updateAttributes(detail) {

--- a/pages/assets/demo-snippet.js
+++ b/pages/assets/demo-snippet.js
@@ -13,6 +13,9 @@ import { validTypes } from './demo-tables.js';
 class ComponentCatalogDemoSnippetWrapper extends LitElement {
 	static get properties() {
 		return {
+			/**
+			 * Default values for demo attributes. Formatted as a stringified object.
+			 */
 			defaults: { type: String },
 			/**
 			* Hide the read-only code view
@@ -34,9 +37,17 @@ class ComponentCatalogDemoSnippetWrapper extends LitElement {
 			* Is the preview resizable
 			*/
 			resizable : { type: Boolean, reflect: true },
+			/**
+			* Size of the IFrame demo portion
+			* @type {'small'|'medium'|'large'|'xlarge'}
+			*/
 			size: { type: String },
+			/**
+			 * The tag of the component being showcased in the demo which has its properties shown (if interactive)
+			 */
 			tagName: { attribute: 'tag-name', type: String },
-			_attributes: { type: Object, reflect: true }
+			_attributes: { type: Object, reflect: true },
+			_demoSnippet:  { type: String },
 		};
 	}
 	static get styles() {
@@ -80,8 +91,8 @@ class ComponentCatalogDemoSnippetWrapper extends LitElement {
 
 	get code() {
 		// remove comment lines from code snippet
-		if (!this.demoSnippet) return '';
-		const lines = this.demoSnippet.split('-->');
+		if (!this._demoSnippet) return '';
+		const lines = this._demoSnippet.split('-->');
 		const codeSnippet = lines.length === 1 ? lines[0] : lines[1]; // if there was no `-->` found lines[1] will be null
 		if (this.interactive) {
 			const splitItems = codeSnippet.split('$attributes');
@@ -116,7 +127,7 @@ class ComponentCatalogDemoSnippetWrapper extends LitElement {
 	}
 
 	get imports() {
-		return parseImports(this.demoSnippet);
+		return parseImports(this._demoSnippet);
 	}
 
 	connectedCallback() {
@@ -133,7 +144,7 @@ class ComponentCatalogDemoSnippetWrapper extends LitElement {
 	}
 
 	render() {
-		if (!this.demoSnippet) return html`<slot @slotchange="${this._handleSlotChange}"></slot>`;
+		if (!this._demoSnippet) return html`<slot @slotchange="${this._handleSlotChange}"></slot>`;
 		const codeSnippet = this.code;
 
 		return html`
@@ -178,7 +189,7 @@ class ComponentCatalogDemoSnippetWrapper extends LitElement {
 	_handleSlotChange() {
 		const slot = this.shadowRoot.querySelector('slot');
 		if (slot && slot.assignedNodes().length > 0) {
-			this.demoSnippet = slot.assignedNodes()[0].textContent;
+			this._demoSnippet = slot.assignedNodes()[0].textContent;
 			this._highlightedCodeSnippet = Prism.highlight(this.code, Prism.languages[this.language], this.language);
 		}
 	}

--- a/pages/assets/utils.mjs
+++ b/pages/assets/utils.mjs
@@ -2,28 +2,6 @@ const defaultImports = [
 	'import \'@brightspace-ui/core/components/typography/typography.js?module\';\n',
 ];
 
-export function parseConfigurationValue(tag, demoSnippet, requireSplitOnNewlines) {
-	let value;
-
-	if (requireSplitOnNewlines && !demoSnippet.includes('\n')) {
-		throw new Error('Snippet info should be divided by newlines.');
-	}
-
-	if (demoSnippet.includes(`${tag}:`)) {
-		let section = demoSnippet.split('-->')[0];
-		const splitsOnNewlines = section.includes('\n');
-		section = section.split(`${tag}:`)[1];
-
-		if (splitsOnNewlines) {
-			if (section.includes('\n')) value = section.split('\n')[0];
-			else value = section; // last one and --> was on last line instead of below
-		} else {
-			value = section.split(' ')[0];
-		}
-	}
-	return value ? value.trim() : undefined;
-}
-
 export const parseImports = (allContent) => {
 	const content = /<script.*>([\s\S]*)<\/script>/g.exec(allContent);
 	if (!content || content.length !== 2 || content[1] === '') return '';

--- a/pages/demo.md
+++ b/pages/demo.md
@@ -6,7 +6,7 @@ layout: layouts/demo
 
 ### Interactive demo - Includes text variations for coloring [demo-snippet]
 
-<!-- docs: live demo name:d2l-button -->
+<!-- docs: demo live name:d2l-button -->
 ```html
 <script type="module">
 	/*
@@ -16,7 +16,7 @@ layout: layouts/demo
 	import '@brightspace-ui/core/components/button/button-subtle.js';
 	import '@brightspace-ui/core/components/button/button-icon.js';
 
-	// A normal comment 
+	// A normal comment
 	function fun() {
 		console.log("Test Function");
 		const x = 4 * 5;
@@ -25,7 +25,7 @@ layout: layouts/demo
 </script>
 <style>
 	@import url(https://fonts.googleapis.com/css?family=Questrial);
-	
+
 	html {
 		padding: 0 !important;
 	}
@@ -38,7 +38,7 @@ layout: layouts/demo
 ```
 ### Interactive demo - size
 
-<!-- docs: live demo
+<!-- docs: demo live
 name:d2l-button
 size:medium
 defaults:{"disabled":true}
@@ -53,6 +53,16 @@ defaults:{"disabled":true}
 ### Demo - non-interactive
 
 <!-- docs: demo -->
+```html
+<script type="module">
+	import '@brightspace-ui/core/components/button/button.js';
+</script>
+<d2l-button>Button</d2l-button>
+```
+
+### Demo - non-interactive w/ code
+
+<!-- docs: demo code size:large-->
 ```html
 <script type="module">
 	import '@brightspace-ui/core/components/button/button.js';

--- a/pages/demo.md
+++ b/pages/demo.md
@@ -6,8 +6,8 @@ layout: layouts/demo
 
 ### Interactive demo - Includes text variations for coloring [demo-snippet]
 
-```html
 <!-- docs: live demo name:d2l-button -->
+```html
 <script type="module">
 	/*
 		Block comment
@@ -38,12 +38,12 @@ layout: layouts/demo
 ```
 ### Interactive demo - size
 
-```html
-<!-- docs: live demo 
+<!-- docs: live demo
 name:d2l-button
 size:medium
 defaults:{"disabled":true}
 -->
+```html
 <script type="module">
 	import '@brightspace-ui/core/components/button/button.js';
 </script>
@@ -52,8 +52,8 @@ defaults:{"disabled":true}
 
 ### Demo - non-interactive
 
-```html
 <!-- docs: demo -->
+```html
 <script type="module">
 	import '@brightspace-ui/core/components/button/button.js';
 </script>

--- a/test/component-utils.test.mjs
+++ b/test/component-utils.test.mjs
@@ -1,5 +1,5 @@
-import { parseConfigurationValue, parseImports } from '../pages/assets/utils.mjs';
 import assert from 'assert';
+import { parseImports } from '../pages/assets/utils.mjs';
 
 describe('component-utils', () => {
 	describe('parseImports', () => {
@@ -88,86 +88,6 @@ import '@brightspace-ui/core/components/button/button.js?module';\n`
 			it(`should return correct result when ${test.name}`, () => {
 				assert.equal(parseImports(test.snippet), test.expected);
 			});
-		});
-	});
-
-	describe('parseConfigurationValue', () => {
-		it('should return correct result when inline', () => {
-			const snippet = '<!-- docs: demo name:d2l-component size:small -->';
-			assert.equal(parseConfigurationValue('name', snippet), 'd2l-component');
-			assert.equal(parseConfigurationValue('size', snippet), 'small');
-		});
-
-		it('should return correct result when inline with code', () => {
-			const snippet = `<!-- docs: demo name:d2l-component size:small -->
-<d2l-component></d2l-component>`;
-			assert.equal(parseConfigurationValue('name', snippet), 'd2l-component');
-			assert.equal(parseConfigurationValue('size', snippet), 'small');
-		});
-
-		it('should return nothing when tag not present', () => {
-			const snippet = '<!-- docs: demo name:d2l-component size:small -->';
-			assert.equal(parseConfigurationValue('tag2', snippet), undefined);
-		});
-
-		it('should throw if inline and requires being split on new lines', () => {
-			const snippet = '<!-- docs: demo name:d2l-component size:small defaults:{"type":"hello"} -->';
-			assert.throws(() => { parseConfigurationValue('name', snippet, true); });
-		});
-
-		it('should return correct result when multi-line', () => {
-			const snippet = `<!-- docs: demo
-name:d2l-component
-size:small
--->`;
-			assert.equal(parseConfigurationValue('name', snippet), 'd2l-component');
-			assert.equal(parseConfigurationValue('size', snippet), 'small');
-		});
-
-		it('should return correct result when multi-line with code', () => {
-			const snippet = `<!-- docs: demo
-name:d2l-component
-size:small
--->
-<d2l-component></d2l-component>`;
-			assert.equal(parseConfigurationValue('name', snippet), 'd2l-component');
-			assert.equal(parseConfigurationValue('size', snippet), 'small');
-		});
-
-		it('should return correct result when multi-line with comment close on last line', () => {
-			const snippet = `<!-- docs: demo
-name:d2l-component
-size:small -->`;
-			assert.equal(parseConfigurationValue('name', snippet), 'd2l-component');
-			assert.equal(parseConfigurationValue('size', snippet), 'small');
-		});
-
-		it('should return correct result when multi-line with space', () => {
-			const snippet = `<!-- docs: demo
-name: d2l-component
-size: small -->`;
-			assert.equal(parseConfigurationValue('name', snippet), 'd2l-component');
-			assert.equal(parseConfigurationValue('size', snippet), 'small');
-		});
-
-		it('should return correct result when multi-line with space', () => {
-			const snippet = `<!-- docs: demo
-name: d2l-component
-size: small
--->`;
-			assert.equal(parseConfigurationValue('name', snippet), 'd2l-component');
-			assert.equal(parseConfigurationValue('size', snippet), 'small');
-		});
-
-		it('should return correct result when multi-line with defaults', () => {
-			const snippet = `<!-- docs: demo
-name: d2l-component
-size: small
-defaults: {"type":"type1", "other": true}
--->`;
-			assert.equal(parseConfigurationValue('name', snippet, true), 'd2l-component');
-			assert.equal(parseConfigurationValue('size', snippet, true), 'small');
-			assert.equal(parseConfigurationValue('defaults', snippet, true), '{"type":"type1", "other": true}');
 		});
 	});
 

--- a/test/component-utils.test.mjs
+++ b/test/component-utils.test.mjs
@@ -16,7 +16,7 @@ describe('component-utils', () => {
 import '@brightspace-ui/core/components/button/button.js?module';\n`
 			}, {
 				name: 'interactive demo snippet',
-				snippet: `<!-- docs: live demo
+				snippet: `<!-- docs: demo live
 name:<component-tag, e.g., d2l-button>
 size:<'small'|'medium'|'large'|'xlarge'>
 -->
@@ -28,7 +28,7 @@ size:<'small'|'medium'|'large'|'xlarge'>
 import '@brightspace-ui/core/components/button/button.js?module';\n`
 			}, {
 				name: 'secondary demo snippet',
-				snippet: `<!-- docs: code demo -->
+				snippet: `<!-- docs: demo code -->
 <script type="module">
 	import '@brightspace-ui/core/components/button/button.js';
 </script>

--- a/test/eleventy-utils.test.js
+++ b/test/eleventy-utils.test.js
@@ -1,0 +1,84 @@
+const assert = require('assert');
+const { parseConfigurationValue } = require('../tools/eleventy-utils');
+
+describe('eleventy-utils', () => {
+	describe('parseConfigurationValue', () => {
+		it('should return correct result when inline', () => {
+			const snippet = '<!-- docs: demo name:d2l-component size:small -->';
+			assert.equal(parseConfigurationValue('name', snippet), 'd2l-component');
+			assert.equal(parseConfigurationValue('size', snippet), 'small');
+		});
+
+		it('should return correct result when inline with code', () => {
+			const snippet = `<!-- docs: demo name:d2l-component size:small -->
+<d2l-component></d2l-component>`;
+			assert.equal(parseConfigurationValue('name', snippet), 'd2l-component');
+			assert.equal(parseConfigurationValue('size', snippet), 'small');
+		});
+
+		it('should return nothing when tag not present', () => {
+			const snippet = '<!-- docs: demo name:d2l-component size:small -->';
+			assert.equal(parseConfigurationValue('tag2', snippet), undefined);
+		});
+
+		it('should throw if inline and requires being split on new lines', () => {
+			const snippet = '<!-- docs: demo name:d2l-component size:small defaults:{"type":"hello"} -->';
+			assert.throws(() => { parseConfigurationValue('name', snippet, true); });
+		});
+
+		it('should return correct result when multi-line', () => {
+			const snippet = `<!-- docs: demo
+name:d2l-component
+size:small
+-->`;
+			assert.equal(parseConfigurationValue('name', snippet), 'd2l-component');
+			assert.equal(parseConfigurationValue('size', snippet), 'small');
+		});
+
+		it('should return correct result when multi-line with code', () => {
+			const snippet = `<!-- docs: demo
+name:d2l-component
+size:small
+-->
+<d2l-component></d2l-component>`;
+			assert.equal(parseConfigurationValue('name', snippet), 'd2l-component');
+			assert.equal(parseConfigurationValue('size', snippet), 'small');
+		});
+
+		it('should return correct result when multi-line with comment close on last line', () => {
+			const snippet = `<!-- docs: demo
+name:d2l-component
+size:small -->`;
+			assert.equal(parseConfigurationValue('name', snippet), 'd2l-component');
+			assert.equal(parseConfigurationValue('size', snippet), 'small');
+		});
+
+		it('should return correct result when multi-line with space', () => {
+			const snippet = `<!-- docs: demo
+name: d2l-component
+size: small -->`;
+			assert.equal(parseConfigurationValue('name', snippet), 'd2l-component');
+			assert.equal(parseConfigurationValue('size', snippet), 'small');
+		});
+
+		it('should return correct result when multi-line with space', () => {
+			const snippet = `<!-- docs: demo
+name: d2l-component
+size: small
+-->`;
+			assert.equal(parseConfigurationValue('name', snippet), 'd2l-component');
+			assert.equal(parseConfigurationValue('size', snippet), 'small');
+		});
+
+		it('should return correct result when multi-line with defaults', () => {
+			const snippet = `<!-- docs: demo
+name: d2l-component
+size: small
+defaults: {"type":"type1", "other": true}
+-->`;
+			assert.equal(parseConfigurationValue('name', snippet, true), 'd2l-component');
+			assert.equal(parseConfigurationValue('size', snippet, true), 'small');
+			assert.equal(parseConfigurationValue('defaults', snippet, true), '{"type":"type1", "other": true}');
+		});
+	});
+});

--- a/tools/eleventy-utils.js
+++ b/tools/eleventy-utils.js
@@ -1,0 +1,25 @@
+module.exports = {
+	parseConfigurationValue: (tag, demoSnippet, requireSplitOnNewlines) => {
+		let value;
+
+		if (!demoSnippet) return undefined;
+
+		if (requireSplitOnNewlines && !demoSnippet.includes('\n')) {
+			throw new Error('Snippet info should not be divided by spaces if using "defaults" due to parsing. Use multi-line method.');
+		}
+
+		if (demoSnippet.includes(`${tag}:`)) {
+			let section = demoSnippet.split('-->')[0];
+			const splitsOnNewlines = section.includes('\n');
+			section = section.split(`${tag}:`)[1];
+
+			if (splitsOnNewlines) {
+				if (section.includes('\n')) value = section.split('\n')[0];
+				else value = section; // last one and --> was on last line instead of below
+			} else {
+				value = section.split(' ')[0];
+			}
+		}
+		return value ? value.trim() : undefined;
+	}
+};


### PR DESCRIPTION
This allows for the code information comment to come before the code block.