### PR TITLE
Demo: remove $attributes

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -113,8 +113,13 @@ module.exports = function(eleventyConfig) {
 				if (!tag) return `${openingTag} hide-code>`;
 
 				openingTag += ` resizable interactive tag-name="${tag}" `;
+
 				const defaults = parseConfigurationValue('defaults', content, true);
 				if (defaults) openingTag += ` defaults='${defaults}'`;
+
+				const allInstancesInteractive = parseConfigurationValue('allInstancesInteractive', content);
+				if (allInstancesInteractive === 'true') openingTag += ' all-instances-interactive';
+
 				return `${openingTag}>`;
 			} else if (content.includes('<!-- docs: demo code')) {
 				return `${openingTag}>`;

--- a/docs/adding-component.md
+++ b/docs/adding-component.md
@@ -77,7 +77,7 @@ size:<'small'|'medium'|'large'|'xlarge'>
 
 **Interactive demo**: (maximum of 1 per component) This demo includes the properties, slots, and events tables, and allows for the user to modify properties in these table(s) which then affects the demo.
 
-Add the comment `<!-- docs: demo live -->` directly before the code block and `$attributes` on the component tag. Note that if `defaults` is being used in order to set default demo values, the demo information pieces must be separated by newlines rather than be inline (e.g., `<!-- docs: demo live name:d2l-button -->`). For example:
+Add the comment `<!-- docs: demo live -->` directly before the code block. Note that if `defaults` is being used in order to set default demo values, the demo information pieces must be separated by newlines rather than be inline (e.g., `<!-- docs: demo live name:d2l-button -->`). For example:
 ```
 <!-- docs: demo live
 name:<component-tag, e.g., d2l-button>
@@ -88,7 +88,30 @@ defaults:{"<attribute>": <value: "string"|boolean|number>}>
 <script type="module">
   import '@brightspace-ui/core/components/button/button.js';
 </script>
-<d2l-button $attributes></d2l-button>
+<d2l-button></d2l-button>
+\`\`\`
+```
+
+If there are multiple instances of the same component in a demo (e.g., menu-item) and they all should be affected by changes to the properties table, set `allInstancesInteractive` to true. If this is not present and true then only the first instance of the component will be affected by changes to the properties table. For example:
+```
+<!-- docs: demo live
+name:d2l-menu-item
+allInstancesInteractive:true
+>
+-->
+```html
+<script type="module">
+  import '@brightspace-ui/core/components/menu/menu.js';
+  import '@brightspace-ui/core/components/menu/menu-item.js';
+</script>
+<d2l-menu label="Astronomy">
+  <d2l-menu-item text="Introduction"></d2l-menu-item>
+  <d2l-menu-item text="The Solar System">
+    <d2l-menu>
+      <d2l-menu-item text="Formation"></d2l-menu-item>
+    </d2l-menu>
+  </d2l-menu-item>
+</d2l-menu>
 \`\`\`
 ```
 

--- a/pages/assets/demo-snippet.js
+++ b/pages/assets/demo-snippet.js
@@ -1,18 +1,22 @@
 import '@brightspace-ui/core/components/colors/colors.js';
 import '@brightspace-ui/core/components/demo/demo-snippet.js';
 import './demo-resizable-preview.js';
+import './demo-tables.js';
 import 'playground-elements/playground-code-editor';
 import 'prismjs/prism.js';
 import { css, html, LitElement } from 'lit-element';
+import { getCode, parseImports } from './utils.mjs';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
-import { parseImports } from './utils.mjs';
 import { themeStyles } from './code-style.js';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html';
-import { validTypes } from './demo-tables.js';
 
 class ComponentCatalogDemoSnippetWrapper extends LitElement {
 	static get properties() {
 		return {
+			/**
+			 * If true then all instances of tagName component are affected by property table changes, else only the first
+			 */
+			allInstancesInteractive: { type: Boolean, attribute: 'all-instances-interactive' },
 			/**
 			 * Default values for demo attributes. Formatted as a stringified object.
 			 */
@@ -82,6 +86,7 @@ class ComponentCatalogDemoSnippetWrapper extends LitElement {
 	constructor() {
 		super();
 		this._attributes = {};
+		this.allInstancesInteractive = false;
 		this.hideCode = false;
 		this.hideDemo = false;
 		this.interactive = false;
@@ -90,7 +95,7 @@ class ComponentCatalogDemoSnippetWrapper extends LitElement {
 	}
 
 	get code() {
-		return getCode(this._demoSnippet, this.interactive, this._attributes);
+		return getCode(this._demoSnippet, this.interactive, this._attributes, this.tagName, this.allInstancesInteractive);
 	}
 
 	get imports() {

--- a/pages/assets/demo-snippet.js
+++ b/pages/assets/demo-snippet.js
@@ -90,40 +90,7 @@ class ComponentCatalogDemoSnippetWrapper extends LitElement {
 	}
 
 	get code() {
-		// remove comment lines from code snippet
-		if (!this._demoSnippet) return '';
-		const lines = this._demoSnippet.split('-->');
-		const codeSnippet = lines.length === 1 ? lines[0] : lines[1]; // if there was no `-->` found lines[1] will be null
-		if (this.interactive) {
-			const splitItems = codeSnippet.split('$attributes');
-			if (splitItems.length === 2) {
-
-				const attributes = [];
-				for (const attribute in this._attributes) {
-					const { type, value } = this._attributes[attribute];
-					switch (type) {
-						case validTypes.string:
-							attributes.push(`${attribute}="${value}"`);
-							break;
-						case validTypes.boolean:
-							attributes.push(`${attribute}`);
-							break;
-						case validTypes.number:
-							attributes.push(`${attribute}=${value}`);
-							break;
-						default:
-							break;
-					}
-				}
-				attributes.sort();
-				const attributesText = attributes.length === 0 ? '' : ` ${attributes.join(' ')}`;
-				// Append the code snippet back together with our edited attributes
-				const withAttributes = `${splitItems[0].trim()}${attributesText}${splitItems[1]}`;
-				return `${withAttributes}`;
-			}
-		}
-
-		return codeSnippet;
+		return getCode(this._demoSnippet, this.interactive, this._attributes);
 	}
 
 	get imports() {

--- a/pages/assets/demo-tables.js
+++ b/pages/assets/demo-tables.js
@@ -8,13 +8,7 @@ import { customTableStyles } from './table-style.js';
 import { heading4Styles } from '@brightspace-ui/core/components/typography/styles.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { selectStyles } from '@brightspace-ui/core/components/inputs/input-select-styles.js';
-export const validTypes = {
-	array: 'array',
-	boolean: 'boolean',
-	number: 'number',
-	object: 'object',
-	string: 'string'
-};
+import { validTypes } from './utils.mjs';
 
 export class ComponentCatalogDemoTables extends LitElement {
 	static get properties() {

--- a/pages/assets/utils.mjs
+++ b/pages/assets/utils.mjs
@@ -38,12 +38,9 @@ export function getCode(snippet, interactive, currAttributes, tagName, allInstan
 	}
 	attributes.sort();
 	const attributesText = attributes.length === 0 ? '' : ` ${attributes.join(' ')}`;
-	const includesSpace = codeSnippet.includes(`<${tagName} `);
-	const replaceString = includesSpace ? `<${tagName}` : `<${tagName}>`;
-	const re = allInstancesInteractive ? new RegExp(replaceString, 'g') : replaceString;
-	return includesSpace
-		? codeSnippet.replace(re, `<${tagName}${attributesText}`)
-		: codeSnippet.replace(re, `<${tagName}${attributesText}>`);
+	const reString = `(<${tagName})(>)|(<${tagName} [^>]+)(>)`;
+	const re = allInstancesInteractive ? new RegExp(reString, 'g') : new RegExp(reString);
+	return codeSnippet.replace(re, `$1$3${attributesText}>`);
 }
 
 export const parseImports = (allContent) => {

--- a/pages/assets/utils.mjs
+++ b/pages/assets/utils.mjs
@@ -10,41 +10,40 @@ export const validTypes = {
 	string: 'string'
 };
 
-export function getCode(snippet, interactive, currAttributes) {
+export function getCode(snippet, interactive, currAttributes, tagName, allInstancesInteractive) {
 	// remove comment lines from code snippet
 	if (!snippet) return '';
 	const lines = snippet.split('-->');
 	const codeSnippet = lines.length === 1 ? lines[0] : lines[1]; // if there was no `-->` found lines[1] will be null
-	if (interactive) {
-		const splitItems = codeSnippet.split('$attributes');
-		if (splitItems.length === 2) {
 
-			const attributes = [];
-			for (const attribute in currAttributes) {
-				const { type, value } = currAttributes[attribute];
-				switch (type) {
-					case validTypes.string:
-						attributes.push(`${attribute}="${value}"`);
-						break;
-					case validTypes.boolean:
-						if (value)
-							attributes.push(`${attribute}`);
-						break;
-					case validTypes.number:
-						attributes.push(`${attribute}=${value}`);
-						break;
-					default:
-						break;
-				}
-			}
-			attributes.sort();
-			const attributesText = attributes.length === 0 ? '' : ` ${attributes.join(' ')}`;
-			// Append the code snippet back together with our edited attributes
-			const withAttributes = `${splitItems[0].trim()}${attributesText}${splitItems[1]}`;
-			return `${withAttributes}`;
+	if (!interactive) return codeSnippet;
+
+	const attributes = [];
+	for (const attribute in currAttributes) {
+		const { type, value } = currAttributes[attribute];
+		switch (type) {
+			case validTypes.string:
+				attributes.push(`${attribute}="${value}"`);
+				break;
+			case validTypes.boolean:
+				if (value)
+					attributes.push(`${attribute}`);
+				break;
+			case validTypes.number:
+				attributes.push(`${attribute}=${value}`);
+				break;
+			default:
+				break;
 		}
 	}
-	return codeSnippet;
+	attributes.sort();
+	const attributesText = attributes.length === 0 ? '' : ` ${attributes.join(' ')}`;
+	const includesSpace = codeSnippet.includes(`<${tagName} `);
+	const replaceString = includesSpace ? `<${tagName}` : `<${tagName}>`;
+	const re = allInstancesInteractive ? new RegExp(replaceString, 'g') : replaceString;
+	return includesSpace
+		? codeSnippet.replace(re, `<${tagName}${attributesText}`)
+		: codeSnippet.replace(re, `<${tagName}${attributesText}>`);
 }
 
 export const parseImports = (allContent) => {

--- a/pages/assets/utils.mjs
+++ b/pages/assets/utils.mjs
@@ -2,6 +2,51 @@ const defaultImports = [
 	'import \'@brightspace-ui/core/components/typography/typography.js?module\';\n',
 ];
 
+export const validTypes = {
+	array: 'array',
+	boolean: 'boolean',
+	number: 'number',
+	object: 'object',
+	string: 'string'
+};
+
+export function getCode(snippet, interactive, currAttributes) {
+	// remove comment lines from code snippet
+	if (!snippet) return '';
+	const lines = snippet.split('-->');
+	const codeSnippet = lines.length === 1 ? lines[0] : lines[1]; // if there was no `-->` found lines[1] will be null
+	if (interactive) {
+		const splitItems = codeSnippet.split('$attributes');
+		if (splitItems.length === 2) {
+
+			const attributes = [];
+			for (const attribute in currAttributes) {
+				const { type, value } = currAttributes[attribute];
+				switch (type) {
+					case validTypes.string:
+						attributes.push(`${attribute}="${value}"`);
+						break;
+					case validTypes.boolean:
+						if (value)
+							attributes.push(`${attribute}`);
+						break;
+					case validTypes.number:
+						attributes.push(`${attribute}=${value}`);
+						break;
+					default:
+						break;
+				}
+			}
+			attributes.sort();
+			const attributesText = attributes.length === 0 ? '' : ` ${attributes.join(' ')}`;
+			// Append the code snippet back together with our edited attributes
+			const withAttributes = `${splitItems[0].trim()}${attributesText}${splitItems[1]}`;
+			return `${withAttributes}`;
+		}
+	}
+	return codeSnippet;
+}
+
 export const parseImports = (allContent) => {
 	const content = /<script.*>([\s\S]*)<\/script>/g.exec(allContent);
 	if (!content || content.length !== 2 || content[1] === '') return '';

--- a/pages/demo.md
+++ b/pages/demo.md
@@ -34,7 +34,7 @@ layout: layouts/demo
 		color: #ffffff;
 	}
 </style>
-<d2l-button $attributes>Button</d2l-button>
+<d2l-button>Button</d2l-button>
 ```
 ### Interactive demo - size
 
@@ -47,7 +47,7 @@ defaults:{"disabled":true}
 <script type="module">
 	import '@brightspace-ui/core/components/button/button.js';
 </script>
-<d2l-button $attributes>Button</d2l-button>
+<d2l-button>Button</d2l-button>
 ```
 
 ### Demo - non-interactive
@@ -77,6 +77,51 @@ defaults:{"disabled":true}
 	import '@brightspace-ui/core/components/button/button.js';
 </script>
 <d2l-button>Button</d2l-button>
+```
+
+### Multiple Instances, all affected by properties table changes
+
+<!-- docs: demo live
+name:d2l-menu-item
+allInstancesInteractive:true
+defaults:{"text":"Menu Item"}
+>
+-->
+```html
+<script type="module">
+  import '@brightspace-ui/core/components/menu/menu.js';
+  import '@brightspace-ui/core/components/menu/menu-item.js';
+</script>
+<d2l-menu label="Astronomy">
+  <d2l-menu-item></d2l-menu-item>
+  <d2l-menu-item>
+    <d2l-menu>
+      <d2l-menu-item></d2l-menu-item>
+    </d2l-menu>
+  </d2l-menu-item>
+</d2l-menu>
+```
+
+### Multiple Instances, first instance affected by properties table changes
+
+<!-- docs: demo live
+name:d2l-menu-item
+defaults:{"text":"Menu Item"}
+>
+-->
+```html
+<script type="module">
+  import '@brightspace-ui/core/components/menu/menu.js';
+  import '@brightspace-ui/core/components/menu/menu-item.js';
+</script>
+<d2l-menu label="Astronomy">
+  <d2l-menu-item></d2l-menu-item>
+  <d2l-menu-item text="Another Item">
+    <d2l-menu>
+      <d2l-menu-item text="Inner Item"></d2l-menu-item>
+    </d2l-menu>
+  </d2l-menu-item>
+</d2l-menu>
 ```
 
 ### Example Markdown table from README

--- a/test/component-utils.test.mjs
+++ b/test/component-utils.test.mjs
@@ -1,5 +1,5 @@
+import { getCode, parseImports } from '../pages/assets/utils.mjs';
 import assert from 'assert';
-import { parseImports } from '../pages/assets/utils.mjs';
 
 describe('component-utils', () => {
 	describe('parseImports', () => {
@@ -88,6 +88,50 @@ import '@brightspace-ui/core/components/button/button.js?module';\n`
 			it(`should return correct result when ${test.name}`, () => {
 				assert.equal(parseImports(test.snippet), test.expected);
 			});
+		});
+	});
+
+	describe.only('getCode', () => {
+		const comment = `<!-- docs: demo live
+name:d2l-button
+-->`;
+		const basicCode = `<script type="module">
+	import '@brightspace-ui/core/components/button/button.js';
+</script>
+<d2l-button>Button</d2l-button>`;
+		const codeAttributes = '<d2l-button $attributes></d2l-button>';
+
+		it('should return empty string when empty snippet', () => {
+			assert.equal(getCode(), '');
+		});
+
+		it('should return code when just code', () => {
+			assert.equal(getCode(basicCode), basicCode);
+		});
+
+		it('should return code when comment and code', () => {
+			const code = `${comment}${basicCode}`;
+			assert.equal(getCode(code), basicCode);
+		});
+
+		it('should return unmodified code when not interactive', () => {
+			assert.equal(getCode(codeAttributes), codeAttributes);
+		});
+
+		it('should return code when interactive', () => {
+			assert.equal(getCode(codeAttributes, true), '<d2l-button></d2l-button>');
+		});
+
+		it('should return expected code when attributes', () => {
+			const attributes = {
+				'text': { type: 'string', value: 'My button' },
+				'disabled': { type: 'boolean', value: true },
+				'primary': { type: 'boolean', value: false },
+				'sum': { type: 'number', value: 12 },
+				'other': { type: 'invalid', value: 'thing' }
+			};
+			const expected = '<d2l-button disabled sum=12 text="My button"></d2l-button>';
+			assert.equal(getCode(codeAttributes, true, attributes), expected);
 		});
 	});
 

--- a/test/component-utils.test.mjs
+++ b/test/component-utils.test.mjs
@@ -91,15 +91,18 @@ import '@brightspace-ui/core/components/button/button.js?module';\n`
 		});
 	});
 
-	describe.only('getCode', () => {
+	describe('getCode', () => {
+		const attributes = {
+			'text': { type: 'string', value: 'My button' },
+			'disabled': { type: 'boolean', value: true },
+			'primary': { type: 'boolean', value: false },
+			'sum': { type: 'number', value: 12 },
+			'other': { type: 'invalid', value: 'thing' }
+		};
+		const basicCode = '<d2l-button>Button</d2l-button>';
 		const comment = `<!-- docs: demo live
 name:d2l-button
 -->`;
-		const basicCode = `<script type="module">
-	import '@brightspace-ui/core/components/button/button.js';
-</script>
-<d2l-button>Button</d2l-button>`;
-		const codeAttributes = '<d2l-button $attributes></d2l-button>';
 
 		it('should return empty string when empty snippet', () => {
 			assert.equal(getCode(), '');
@@ -114,24 +117,44 @@ name:d2l-button
 			assert.equal(getCode(code), basicCode);
 		});
 
-		it('should return unmodified code when not interactive', () => {
-			assert.equal(getCode(codeAttributes), codeAttributes);
+		it('should return code when interactive', () => {
+			assert.equal(getCode(basicCode, true), basicCode);
 		});
 
-		it('should return code when interactive', () => {
-			assert.equal(getCode(codeAttributes, true), '<d2l-button></d2l-button>');
+		it('should return unmodified code when attributes but no tagName', () => {
+			assert.equal(getCode(basicCode, true, attributes), basicCode);
 		});
 
 		it('should return expected code when attributes', () => {
-			const attributes = {
-				'text': { type: 'string', value: 'My button' },
-				'disabled': { type: 'boolean', value: true },
-				'primary': { type: 'boolean', value: false },
-				'sum': { type: 'number', value: 12 },
-				'other': { type: 'invalid', value: 'thing' }
-			};
-			const expected = '<d2l-button disabled sum=12 text="My button"></d2l-button>';
-			assert.equal(getCode(codeAttributes, true, attributes), expected);
+			const expected = '<d2l-button disabled sum=12 text="My button">Button</d2l-button>';
+			assert.equal(getCode(basicCode, true, attributes, 'd2l-button'), expected);
+		});
+
+		it('should return expected code when attributes and code has space', () => {
+			const code = '<d2l-button other>Button</d2l-button>';
+			const expected = '<d2l-button disabled sum=12 text="My button" other>Button</d2l-button>';
+			assert.equal(getCode(code, true, attributes, 'd2l-button'), expected);
+		});
+
+		it('should only replace first instance', () => {
+			const code = `<d2l-button>Button</d2l-button>
+<d2l-button>Button 2</d2l-button>`;
+			const expected = `<d2l-button disabled sum=12 text="My button">Button</d2l-button>
+<d2l-button>Button 2</d2l-button>`;
+			assert.equal(getCode(code, true, attributes, 'd2l-button'), expected);
+		});
+
+		it('should replace both instances when all is true', () => {
+			const code = `<d2l-button>Button</d2l-button>
+<d2l-button>Button 2</d2l-button>`;
+			const expected = `<d2l-button disabled sum=12 text="My button">Button</d2l-button>
+<d2l-button disabled sum=12 text="My button">Button 2</d2l-button>`;
+			assert.equal(getCode(code, true, attributes, 'd2l-button', true), expected);
+		});
+
+		it('should not replace when tag part of longer tag', () => {
+			const code = '<d2l-button-elem>Button</d2l-button-elem>';
+			assert.equal(getCode(code, true, attributes, 'd2l-button', true), code);
 		});
 	});
 

--- a/test/component-utils.test.mjs
+++ b/test/component-utils.test.mjs
@@ -130,12 +130,6 @@ name:d2l-button
 			assert.equal(getCode(basicCode, true, attributes, 'd2l-button'), expected);
 		});
 
-		it('should return expected code when attributes and code has space', () => {
-			const code = '<d2l-button other>Button</d2l-button>';
-			const expected = '<d2l-button disabled sum=12 text="My button" other>Button</d2l-button>';
-			assert.equal(getCode(code, true, attributes, 'd2l-button'), expected);
-		});
-
 		it('should only replace first instance', () => {
 			const code = `<d2l-button>Button</d2l-button>
 <d2l-button>Button 2</d2l-button>`;
@@ -155,6 +149,68 @@ name:d2l-button
 		it('should not replace when tag part of longer tag', () => {
 			const code = '<d2l-button-elem>Button</d2l-button-elem>';
 			assert.equal(getCode(code, true, attributes, 'd2l-button', true), code);
+		});
+
+		describe('when code has existing attributes', () => {
+
+			it('should return expected code', () => {
+				const code = '<d2l-button other another="value">Button</d2l-button>';
+				const expected = '<d2l-button other another="value" disabled sum=12 text="My button">Button</d2l-button>';
+				assert.equal(getCode(code, true, attributes, 'd2l-button'), expected);
+			});
+
+			it('should return expected code when multiple on same line', () => {
+				const code = '<d2l-button other>Button</d2l-button><d2l-button>Button</d2l-button>';
+				const expected = '<d2l-button other disabled sum=12 text="My button">Button</d2l-button><d2l-button>Button</d2l-button>';
+				assert.equal(getCode(code, true, attributes, 'd2l-button'), expected);
+			});
+
+			it('should return expected code when multiple and second has attributes but not replacing all', () => {
+				const code = '<d2l-button other another="thing2">Button</d2l-button><d2l-button attr="value">Button</d2l-button>';
+				const expected = '<d2l-button other another="thing2" disabled sum=12 text="My button">Button</d2l-button><d2l-button attr="value">Button</d2l-button>';
+				assert.equal(getCode(code, true, attributes, 'd2l-button'), expected);
+			});
+
+			it('should return expected code when multiple and second has attributes and replacing all', () => {
+				const code = '<d2l-button other another="thing2">Button</d2l-button><d2l-button-elem></d2l-button-elem><d2l-button attr="value">Button</d2l-button>';
+				const expected = '<d2l-button other another="thing2" disabled sum=12 text="My button">Button</d2l-button><d2l-button-elem></d2l-button-elem><d2l-button attr="value" disabled sum=12 text="My button">Button</d2l-button>';
+				assert.equal(getCode(code, true, attributes, 'd2l-button', true), expected);
+			});
+
+			it('should return expected code when multiple on different lines and second has attributes and replace all', () => {
+				const code = `<d2l-button other>Button</d2l-button>
+<d2l-button attr="value">Button</d2l-button>
+<d2l-button-elem></d2l-button-elem>`;
+				const expected = `<d2l-button other disabled sum=12 text="My button">Button</d2l-button>
+<d2l-button attr="value" disabled sum=12 text="My button">Button</d2l-button>
+<d2l-button-elem></d2l-button-elem>`;
+				assert.equal(getCode(code, true, attributes, 'd2l-button', true), expected);
+			});
+
+			it('should return expected code when multiple on different lines and second has attributes and not replace all', () => {
+				const code = `<d2l-button other another="thing2">Button</d2l-button>
+<d2l-button attr="value">Button</d2l-button>`;
+				const expected = `<d2l-button other another="thing2" disabled sum=12 text="My button">Button</d2l-button>
+<d2l-button attr="value">Button</d2l-button>`;
+				assert.equal(getCode(code, true, attributes, 'd2l-button'), expected);
+			});
+
+			it('should return expected code when multiple on different lines and second does not have attributes and replace all', () => {
+				const code = `<d2l-button other another="thing2">Button</d2l-button>
+<d2l-button>Button</d2l-button>`;
+				const expected = `<d2l-button other another="thing2" disabled sum=12 text="My button">Button</d2l-button>
+<d2l-button disabled sum=12 text="My button">Button</d2l-button>`;
+				assert.equal(getCode(code, true, attributes, 'd2l-button', true), expected);
+			});
+
+			it('should return expected code when multiple on different lines and second does not have attributes and not replace all', () => {
+				const code = `<d2l-button other>Button</d2l-button>
+<d2l-button>Button</d2l-button>`;
+				const expected = `<d2l-button other disabled sum=12 text="My button">Button</d2l-button>
+<d2l-button>Button</d2l-button>`;
+				assert.equal(getCode(code, true, attributes, 'd2l-button'), expected);
+			});
+
 		});
 	});
 

--- a/test/eleventy-utils.test.js
+++ b/test/eleventy-utils.test.js
@@ -80,5 +80,18 @@ defaults: {"type":"type1", "other": true}
 			assert.equal(parseConfigurationValue('size', snippet, true), 'small');
 			assert.equal(parseConfigurationValue('defaults', snippet, true), '{"type":"type1", "other": true}');
 		});
+
+		it('should return correct result when multi-line with defaults and allInstancesInteractive', () => {
+			const snippet = `<!-- docs: demo
+name: d2l-component
+size: small
+allInstancesInteractive:true
+defaults: {"type":"type1", "other": true}
+-->`;
+			assert.equal(parseConfigurationValue('name', snippet, true), 'd2l-component');
+			assert.equal(parseConfigurationValue('size', snippet, true), 'small');
+			assert.equal(parseConfigurationValue('allInstancesInteractive', snippet, true), 'true');
+			assert.equal(parseConfigurationValue('defaults', snippet, true), '{"type":"type1", "other": true}');
+		});
 	});
 });


### PR DESCRIPTION
This adds support for `allInstancesInteractive` in the code comment, which if true then all instances of the component under `name` are affected by properties table changes (and defaults) and if not present or false then only the first instance of that component is affected.

I also moved the contents of `code` out to a separate file so that I could add tests.