### PR TITLE
Component analyzer: Support @custom-elements-manifest/analyzer

### DIFF
--- a/pages/assets/demo-tables.js
+++ b/pages/assets/demo-tables.js
@@ -159,8 +159,8 @@ export class ComponentCatalogDemoTables extends LitElement {
 	}
 
 	_getDemoValueOptions(type, attributeName, defaultVal) {
-		const strippedDefaultVal = defaultVal?.replace(/"/g, '');
-		const value = defaultVal ? strippedDefaultVal : undefined;
+		let strippedDefaultVal = defaultVal?.replace(/"/g, '');
+		let value = defaultVal ? strippedDefaultVal : undefined;
 		switch (type) {
 			case validTypes.array:
 			case validTypes.object:
@@ -194,6 +194,10 @@ export class ComponentCatalogDemoTables extends LitElement {
 			default: {
 				// the case of an array of strings
 				let options = type.replace(/'/g, '').split(' | ');
+				if (strippedDefaultVal === undefined) {
+					strippedDefaultVal = '';
+					value = '';
+				}
 
 				// Add empty default values to the dropdown lists
 				if (!options.includes(strippedDefaultVal)) {

--- a/pages/assets/demo-tables.js
+++ b/pages/assets/demo-tables.js
@@ -159,6 +159,7 @@ export class ComponentCatalogDemoTables extends LitElement {
 	}
 
 	_getDemoValueOptions(type, attributeName, defaultVal) {
+		if (!type) return;
 		let strippedDefaultVal = defaultVal?.replace(/"/g, '');
 		let value = defaultVal ? strippedDefaultVal : undefined;
 		switch (type) {

--- a/tools/generate-pages.mjs
+++ b/tools/generate-pages.mjs
@@ -69,8 +69,8 @@ function _copyCustomElements(repos) {
 				if (attributeMember.description || !declaration.attributes) return;
 
 				const attributeName = attributeMember.attribute;
-				const attributeData = declaration.attributes.filter((attribute) => attribute.name === attributeName);
-				if (attributeData.length === 1) attributeMember.description = attributeData[0].description;
+				const attributeData = declaration.attributes.find((attribute) => attribute.name === attributeName);
+				if (attributeData) attributeMember.description = attributeData.description;
 			});
 			const info = {
 				name: declaration.tagName,


### PR DESCRIPTION
These are the tweaks needed in order to support `@custom-elements-manifest/analyzer`.

This new analyzer returns a lot more than the previous one, so I used the pre-processing script to filter some pieces out and get it into the format expected by `demo-tables`, which allows us to support the existing `custom-elements.json` and the new version.

Related core PR https://github.com/BrightspaceUI/core/pull/1488